### PR TITLE
[#32] 디렉터 목록 조회 기능 코드 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,15 +2,34 @@ name: CD with Gradle
 
 on:
   push:
-    branches: [ "main", "tilsong:feature/**" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "tilsong:feature/**" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read
 
 jobs:
-  build:
+  build-test:
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: "adopt"
+
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
+
+  deploy:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/src/main/java/com/directors/application/region/RegionService.java
+++ b/src/main/java/com/directors/application/region/RegionService.java
@@ -84,7 +84,6 @@ public class RegionService {
         return userRegion;
     }
 
-
     private Region regionDataLineToRegion(String regionLine) {
         String[] lineSplit = regionLine.split(",");
         return Region.of(lineSplit[0], lineSplit[1], coordinateToPoint(lineSplit[2], lineSplit[3]));

--- a/src/main/java/com/directors/application/region/RegionService.java
+++ b/src/main/java/com/directors/application/region/RegionService.java
@@ -3,6 +3,7 @@ package com.directors.application.region;
 import com.directors.domain.region.Address;
 import com.directors.domain.region.Region;
 import com.directors.domain.region.RegionRepository;
+import com.directors.domain.user.UserRegion;
 import com.directors.domain.user.UserRegionRepository;
 import com.directors.domain.user.exception.UserRegionNotFoundException;
 import jakarta.annotation.PostConstruct;
@@ -58,15 +59,31 @@ public class RegionService {
 
     @Transactional
     public List<Address> getNearestAddress(String userId, int distance) {
-        var userRegion = userRegionRepository
-                .findByUserId(userId)
-                .orElseThrow(() -> new UserRegionNotFoundException(userId));
+        UserRegion userRegion = getUserRegion(userId);
 
         return getNearestRegion(userRegion.getRegion(), distance)
                 .stream()
                 .map(Region::getAddress)
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public List<Long> getNearestRegionId(String userId, int distance) {
+        UserRegion userRegion = getUserRegion(userId);
+
+        return getNearestRegion(userRegion.getRegion(), distance)
+                .stream()
+                .map(Region::getId)
+                .collect(Collectors.toList());
+    }
+
+    private UserRegion getUserRegion(String userId) {
+        var userRegion = userRegionRepository
+                .findByUserId(userId)
+                .orElseThrow(() -> new UserRegionNotFoundException(userId));
+        return userRegion;
+    }
+
 
     private Region regionDataLineToRegion(String regionLine) {
         String[] lineSplit = regionLine.split(",");

--- a/src/main/java/com/directors/application/user/SearchDirectorService.java
+++ b/src/main/java/com/directors/application/user/SearchDirectorService.java
@@ -1,13 +1,13 @@
 package com.directors.application.user;
 
 import com.directors.application.region.RegionService;
-import com.directors.domain.region.Address;
 import com.directors.domain.schedule.Schedule;
 import com.directors.domain.schedule.ScheduleRepository;
 import com.directors.domain.schedule.ScheduleStatus;
-import com.directors.domain.user.*;
+import com.directors.domain.user.User;
+import com.directors.domain.user.UserRepository;
+import com.directors.domain.user.UserStatus;
 import com.directors.domain.user.exception.NoSuchUserException;
-import com.directors.domain.user.exception.UserRegionNotFoundException;
 import com.directors.presentation.user.request.SearchDirectorRequest;
 import com.directors.presentation.user.response.GetDirectorResponse;
 import com.directors.presentation.user.response.SearchDirectorResponse;
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,11 +23,11 @@ import java.util.stream.Collectors;
 public class SearchDirectorService {
     private final RegionService regionService;
     private final UserRepository userRepository;
-    private final UserRegionRepository userRegionRepository;
     private final ScheduleRepository scheduleRepository;
 
     public GetDirectorResponse getDirector(String directorId) {
         var director = getDirectorByDirectorId(directorId);
+
         // TODO: 04.25 Schedule 도메인 Jpa 적용 후 변경 필요. -> User 클래스 내에 다 있도록.
         var startTimeList = getScheduleStartTimesByDirectorId(director.getId());
 
@@ -37,15 +36,15 @@ public class SearchDirectorService {
 
     public List<SearchDirectorResponse> searchDirector(SearchDirectorRequest request, String userId) {
         // TODO: 04.10 Option -> 자기 소개 엔티티 or VO 추가 여부 , Sorting -> 검색에 평점(높은 순, 최소), 요청된 질문 수 반영 여부
-        var users = getNearestDirectors(userId, request.distance());
 
-        // TODO: 04.25 Schedule 도메인 Jpa 적용 후 변경 필요. -> User 클래스 내에 다 있도록.
-        users = filterUserIdBySchedule(users, request.hasSchedule());
-        users = users.stream()
-                .filter(user -> user.hasText(request.searchText()) || user.hasProperty(request.property()))
-                .collect(Collectors.toList());
-        // TODO: 04.25 이 메소드의 내용을 조인 쿼리 + 페이징을 통해서 구현해보기
-        return paging(request.size(), request.page(), generateDirectors(users));
+        List<Long> nearestRegionIds = regionService.getNearestRegionId(userId, request.distance());
+
+        int offset = calcOffset(request.page(), request.size());
+
+        // TODO: 04.26 Schedule 도메인 Jpa 적용 후 변경 필요.
+        List<User> users = userRepository.findWithSearchConditions(nearestRegionIds, request.searchText(), request.property(), offset, request.size());
+
+        return generateDirectors(users);
     }
 
     private User getDirectorByDirectorId(String directorId) {
@@ -62,39 +61,8 @@ public class SearchDirectorService {
                 .collect(Collectors.toList());
     }
 
-    private List<User> getNearestDirectors(String userId, int distance) {
-        var nearestAddress = regionService.getNearestAddress(userId, distance);
-
-        List<UserRegion> userRegionList = new ArrayList<>();
-
-        for (Address address : nearestAddress) {
-            var userRegion = userRegionRepository
-                    .findByFullAddress(address.getFullAddress());
-            userRegionList.addAll(userRegion);
-        }
-
-        if (userRegionList.size() == 0) {
-            throw new UserRegionNotFoundException(null);
-        }
-        return userRegionList.stream()
-                .map(userRegion -> userRegion.getUser())
-                .collect(Collectors.toList());
-    }
-
-    private List<User> filterUserIdBySchedule(List<User> users, boolean hasSchedule) {
-        if (!hasSchedule) {
-            return users;
-        }
-        return users.stream()
-                .filter(user -> scheduleRepository.existsByUserIdAndScheduleStatus(user.getId(), ScheduleStatus.OPENED))
-                .collect(Collectors.toList());
-    }
-
-    private static List<SearchDirectorResponse> paging(int size, int page, List<SearchDirectorResponse> responses) {
-        int totalSize = responses.size();
-        int fromIndex = (page - 1) * size;
-        int toIndex = Math.min(fromIndex + size, totalSize);
-        return responses.subList(fromIndex, toIndex);
+    private int calcOffset(int page, int size) {
+        return (page - 1) * size;
     }
 
     private List<SearchDirectorResponse> generateDirectors(List<User> users) {

--- a/src/main/java/com/directors/domain/user/User.java
+++ b/src/main/java/com/directors/domain/user/User.java
@@ -60,16 +60,6 @@ public class User extends BaseEntity {
                 .collect(Collectors.toUnmodifiableList());
     }
 
-    public boolean hasText(String text) {
-        return isMatchingNameOrNickWithText(text) || isMatchingSpecialtyWithText(text);
-    }
-
-    public boolean hasProperty(String property) {
-        return this.specialtyList.stream().
-                anyMatch(specialty ->
-                        specialty.getSpecialtyInfo().getProperty().getValue().equals(property));
-    }
-
     public void setPasswordByEncryption(String encryptedPassword) {
         this.password = encryptedPassword;
     }
@@ -88,14 +78,5 @@ public class User extends BaseEntity {
         if (!this.email.equals(email)) {
             throw new AuthenticationFailedException(this.id);
         }
-    }
-
-    private boolean isMatchingNameOrNickWithText(String text) {
-        return this.id.contains(text) || this.nickname.contains(text);
-    }
-
-    private boolean isMatchingSpecialtyWithText(String text) {
-        return specialtyList.stream()
-                .anyMatch(specialty -> specialty.getSpecialtyInfo().getDescription().contains(text));
     }
 }

--- a/src/main/java/com/directors/domain/user/UserRegionRepository.java
+++ b/src/main/java/com/directors/domain/user/UserRegionRepository.java
@@ -1,12 +1,9 @@
 package com.directors.domain.user;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRegionRepository {
     Optional<UserRegion> findByUserId(String userId);
-
-    List<UserRegion> findByFullAddress(String fullAddress);
 
     boolean existsByUserId(String userId);
 

--- a/src/main/java/com/directors/domain/user/UserRepository.java
+++ b/src/main/java/com/directors/domain/user/UserRepository.java
@@ -1,5 +1,6 @@
 package com.directors.domain.user;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
@@ -8,4 +9,6 @@ public interface UserRepository {
     Optional<User> findById(String id);
 
     User save(User user);
+
+    List<User> findWithSearchConditions(List<Long> regionIds, String searchText, String property, int offset, int limit);
 }

--- a/src/main/java/com/directors/infrastructure/jpa/user/InmemeryUserRegionRepository.java
+++ b/src/main/java/com/directors/infrastructure/jpa/user/InmemeryUserRegionRepository.java
@@ -4,10 +4,8 @@ import com.directors.domain.user.UserRegion;
 import com.directors.domain.user.UserRegionRepository;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class InmemeryUserRegionRepository implements UserRegionRepository {
     Map<String, UserRegion> userRegionMap = new HashMap<>();
@@ -20,14 +18,6 @@ public class InmemeryUserRegionRepository implements UserRegionRepository {
                 .stream()
                 .filter(ur -> ur.getUser().getId().equals(userId))
                 .findFirst();
-    }
-
-    @Override
-    public List<UserRegion> findByFullAddress(String fullAddress) {
-        return userRegionMap.values()
-                .stream()
-                .filter(ur -> ur.getAddress().getFullAddress().equals(fullAddress))
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/directors/infrastructure/jpa/user/InmemoryUserRepository.java
+++ b/src/main/java/com/directors/infrastructure/jpa/user/InmemoryUserRepository.java
@@ -5,6 +5,7 @@ import com.directors.domain.user.UserRepository;
 import com.directors.domain.user.UserStatus;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -12,6 +13,11 @@ public class InmemoryUserRepository implements UserRepository {
     // 더미 데이터 사용
     private final Map<String, User> userMap = new HashMap<>() {{
     }};
+
+    @Override
+    public List<User> findWithSearchConditions(List<Long> nearestRegionIds, String searchText, String property, int offset, int limit) {
+        return null;
+    }
 
     @Override
     public Optional<User> findByIdAndUserStatus(String id, UserStatus userStatus) {

--- a/src/main/java/com/directors/infrastructure/jpa/user/JpaUserRegionRepository.java
+++ b/src/main/java/com/directors/infrastructure/jpa/user/JpaUserRegionRepository.java
@@ -3,13 +3,10 @@ package com.directors.infrastructure.jpa.user;
 import com.directors.domain.user.UserRegion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface JpaUserRegionRepository extends JpaRepository<UserRegion, Long> {
     Optional<UserRegion> findByUserId(String userId);
-
-    List<UserRegion> findByAddressFullAddress(String fullAddress);
 
     boolean existsByUserId(String userId);
 }

--- a/src/main/java/com/directors/infrastructure/jpa/user/JpaUserRepository.java
+++ b/src/main/java/com/directors/infrastructure/jpa/user/JpaUserRepository.java
@@ -3,9 +3,30 @@ package com.directors.infrastructure.jpa.user;
 import com.directors.domain.user.User;
 import com.directors.domain.user.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JpaUserRepository extends JpaRepository<User, String> {
     Optional<User> findByIdAndUserStatus(String id, UserStatus userStatus);
+
+    @Query(
+            value = "SELECT * FROM user u " +
+                    "INNER JOIN user_region ur ON u.id = ur.user_id " +
+                    "LEFT JOIN specialty s ON u.id = s.user_id " +
+                    "WHERE ur.user_id IN (:regionIds) " +
+                    "AND (u.name LIKE CONCAT('%', :searchText, '%') OR u.nickname LIKE CONCAT('%', :searchText, '%')) " +
+                    "AND s.description LIKE CONCAT('%', :property, '%') " +
+                    "LIMIT :limit OFFSET :offset",
+            nativeQuery = true
+    )
+    List<User> findWithSearchConditions(
+            @Param("regionIds") List<Long> regionIds,
+            @Param("searchText") String searchText,
+            @Param("property") String property,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
 }

--- a/src/main/java/com/directors/infrastructure/jpa/user/JpaUserRepository.java
+++ b/src/main/java/com/directors/infrastructure/jpa/user/JpaUserRepository.java
@@ -17,6 +17,7 @@ public interface JpaUserRepository extends JpaRepository<User, String> {
                     "INNER JOIN user_region ur ON u.id = ur.user_id " +
                     "LEFT JOIN specialty s ON u.id = s.user_id " +
                     "WHERE ur.user_id IN (:regionIds) " +
+                    "AND u.user_status = 'JOINED' " +
                     "AND (u.name LIKE CONCAT('%', :searchText, '%') OR u.nickname LIKE CONCAT('%', :searchText, '%')) " +
                     "AND s.description LIKE CONCAT('%', :property, '%') " +
                     "LIMIT :limit OFFSET :offset",

--- a/src/main/java/com/directors/infrastructure/jpa/user/UserRegionRepositoryAdapter.java
+++ b/src/main/java/com/directors/infrastructure/jpa/user/UserRegionRepositoryAdapter.java
@@ -5,7 +5,6 @@ import com.directors.domain.user.UserRegionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,11 +15,6 @@ public class UserRegionRepositoryAdapter implements UserRegionRepository {
     @Override
     public Optional<UserRegion> findByUserId(String userId) {
         return userRegionRepository.findByUserId(userId);
-    }
-
-    @Override
-    public List<UserRegion> findByFullAddress(String fullAddress) {
-        return userRegionRepository.findByAddressFullAddress(fullAddress);
     }
 
     @Override

--- a/src/main/java/com/directors/infrastructure/jpa/user/UserRepositoryAdapter.java
+++ b/src/main/java/com/directors/infrastructure/jpa/user/UserRepositoryAdapter.java
@@ -6,6 +6,7 @@ import com.directors.domain.user.UserStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -27,5 +28,10 @@ public class UserRepositoryAdapter implements UserRepository {
     @Override
     public User save(User user) {
         return userRepository.save(user);
+    }
+
+    @Override
+    public List<User> findWithSearchConditions(List<Long> regionIds, String searchText, String property, int offset, int limit) {
+        return userRepository.findWithSearchConditions(regionIds, searchText, property, offset, limit);
     }
 }


### PR DESCRIPTION
## PR 유형

- [ ] 버그 수정
- [ ] 기능
- [ ] 코드 스타일
- [x] 리팩토링
- [ ] 빌드
- [x] CI/CD
- [ ] 문서
- [ ] 기타
  <br>

## 변경사항

### 변경 전
-  [링크된 이슈](https://github.com/f-lab-edu/directors/issues/32)의 문제점 존재
### 변경 후
- Spring Jpa Data에서 제공하는 Native Query를 사용하여, 테이블 간 조인 및 페이징 처리를 수행하는 코드를 작성했습니다. 
  이를 통해 한 번의 DB 조회를 통해 원하는 DB의 데이터를 가져올 수 있게 되었고, 관련된 자바 코드들을 보다 간결하게 유지할 수 있게 되었습니다.

## 기타
- Github Actions에서 사용되는 cd.yml 파일을 일부 수정했습니다. Pull Request 중일 경우, 빌드 테스트를 진행하도록 하고, PR을 merge 할 경우 빌드 및 배포하도록 로직을 작성했습니다.