### PR TITLE
[#36] JPA 적용 - 채팅, 채팅방 도메인

### DIFF
--- a/src/main/java/com/directors/domain/chat/Chat.java
+++ b/src/main/java/com/directors/domain/chat/Chat.java
@@ -1,31 +1,41 @@
 package com.directors.domain.chat;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.directors.domain.common.BaseEntity;
+import com.directors.domain.room.Room;
+import com.directors.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
 
-import java.time.LocalDateTime;
-
+@Entity
+@Table(name = "chat")
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Builder
-public class Chat {
+public class Chat extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Long roomId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
     private String content;
-    private String sendUserId;
-    private LocalDateTime createTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "send_user_id")
+    private User sendUser;
 
     public void setId(Long id) {
         this.id = id;
     }
 
-    public static Chat of(Long roomId, String content, String sendUserId, LocalDateTime chatTime) {
+    public static Chat of(Room room, String content, User sendUser) {
         return Chat.builder()
-                .roomId(roomId)
+                .room(room)
                 .content(content)
-                .sendUserId(sendUserId)
-                .createTime(chatTime)
+                .sendUser(sendUser)
                 .build();
     }
 }

--- a/src/main/java/com/directors/domain/chat/ChatRepository.java
+++ b/src/main/java/com/directors/domain/chat/ChatRepository.java
@@ -3,7 +3,7 @@ package com.directors.domain.chat;
 import java.util.List;
 
 public interface ChatRepository {
-    List<Chat> findChatListByRoomId(Long roomId, int offset, int size);
+    List<Chat> findChatListByRoomId(Long roomId, int offset, int limit);
 
-    void save(Chat chat);
+    Chat save(Chat chat);
 }

--- a/src/main/java/com/directors/domain/room/Room.java
+++ b/src/main/java/com/directors/domain/room/Room.java
@@ -1,38 +1,60 @@
 package com.directors.domain.room;
 
+import com.directors.domain.chat.Chat;
+import com.directors.domain.common.BaseEntity;
 import com.directors.domain.room.exception.RoomNotFoundException;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.directors.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
 
-import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 
+@Entity
+@Table(name = "room")
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Builder
-public class Room {
+public class Room extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // TODO: 04.28 Question JPA 적용 시 수정
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "question_id")
+    // private Question question;
     private Long questionId;
-    private String directorId;
-    private String questionerId;
-    private LocalDateTime createTime;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "director_id")
+    private User director;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "questioner_id")
+    private User questioner;
+
+    // TODO: 04.28 보통 페이징 방식으로 조회하므로, 유지 여부 생각해보기
+    @OneToMany(mappedBy = "room", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Chat> chatList = new ArrayList<>();
 
     public void setId(Long id) {
         this.id = id;
     }
 
-    public static Room of(Long questionId, String directorId, String questionerId) {
+    // TODO: 04.28 Question JPA 적용 시 수정
+    public static Room of(Long questionId, User director, User questioner) {
         return Room.builder()
                 .questionId(questionId)
-                .directorId(directorId)
-                .questionerId(questionerId)
-                .createTime(LocalDateTime.now())
+                .director(director)
+                .questioner(questioner)
                 .build();
     }
 
     public void validateRoomUser(String sendUserId) {
-        if (!(sendUserId.equals(directorId) || sendUserId.equals(questionerId))) {
+        if (!(sendUserId.equals(this.director.getId()) || sendUserId.equals(this.questioner.getId()))) {
             throw new RoomNotFoundException(this.id, sendUserId);
         }
     }

--- a/src/main/java/com/directors/domain/room/RoomRepository.java
+++ b/src/main/java/com/directors/domain/room/RoomRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 public interface RoomRepository {
 
-    Optional<Room> findByRoomId(Long roomId);
+    Optional<Room> findById(Long roomId);
 
     Optional<Room> findByQuestionId(Long questionId);
 
@@ -13,5 +13,5 @@ public interface RoomRepository {
 
     List<Room> findByQuestionerId(String questionerId);
 
-    void save(Room room);
+    Room save(Room room);
 }

--- a/src/main/java/com/directors/infrastructure/jpa/chat/ChatRepositoryAdapter.java
+++ b/src/main/java/com/directors/infrastructure/jpa/chat/ChatRepositoryAdapter.java
@@ -1,0 +1,25 @@
+package com.directors.infrastructure.jpa.chat;
+
+import com.directors.domain.chat.Chat;
+import com.directors.domain.chat.ChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRepositoryAdapter implements ChatRepository {
+
+    private final JpaChatRepository jpaChatRepository;
+
+    @Override
+    public List<Chat> findChatListByRoomId(Long roomId, int offset, int size) {
+        return jpaChatRepository.findListByRoomId(roomId, offset, size);
+    }
+
+    @Override
+    public Chat save(Chat chat) {
+        return jpaChatRepository.save(chat);
+    }
+}

--- a/src/main/java/com/directors/infrastructure/jpa/chat/InmemoryChatRepository.java
+++ b/src/main/java/com/directors/infrastructure/jpa/chat/InmemoryChatRepository.java
@@ -2,36 +2,34 @@ package com.directors.infrastructure.jpa.chat;
 
 import com.directors.domain.chat.Chat;
 import com.directors.domain.chat.ChatRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-@Repository
 public class InmemoryChatRepository implements ChatRepository {
     Map<Long, Chat> chatmap = new HashMap<>();
 
     @Override
-    public List<Chat> findChatListByRoomId(Long roomId, int offset, int size) {
+    public List<Chat> findChatListByRoomId(Long roomId, int offset, int limit) {
         List<Chat> chatList = new ArrayList<>();
 
-        List<Chat> chatByRoomId = chatmap.values()
-                .stream()
-                .filter(v -> v.getRoomId().equals(roomId))
-                .collect(Collectors.toList());
-
-        for (int i = offset; i < offset + size; i++) {
-            chatList.add(chatByRoomId.get(i));
-        }
+//        List<Chat> chatByRoomId = chatmap.values()
+//                .stream()
+//                .filter(v -> v.getRoomId().equals(roomId))
+//                .collect(Collectors.toList());
+//
+//        for (int i = offset; i < offset + size; i++) {
+//            chatList.add(chatByRoomId.get(i));
+//        }
 
         return chatList;
     }
 
     @Override
-    public void save(Chat chat) {
+    public Chat save(Chat chat) {
         chatmap.put(chat.getId(), chat);
+        return chat;
     }
 }

--- a/src/main/java/com/directors/infrastructure/jpa/chat/JpaChatRepository.java
+++ b/src/main/java/com/directors/infrastructure/jpa/chat/JpaChatRepository.java
@@ -1,0 +1,24 @@
+package com.directors.infrastructure.jpa.chat;
+
+import com.directors.domain.chat.Chat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface JpaChatRepository extends JpaRepository<Chat, Long> {
+    @Query(
+            value = "SELECT c.content, c.createdTime FROM chat c " +
+                    "LEFT JOIN room r ON c.room_id = r.id " +
+                    "WHERE c.room_id = :roomId " +
+                    "ORDER BY c.createdTime DESC " +
+                    "LIMIT :limit OFFSET :offset",
+            nativeQuery = true
+    )
+    List<Chat> findListByRoomId(
+            @Param("roomId") Long roomId,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+}

--- a/src/main/java/com/directors/infrastructure/jpa/room/InmemeoryRoomRepository.java
+++ b/src/main/java/com/directors/infrastructure/jpa/room/InmemeoryRoomRepository.java
@@ -2,7 +2,6 @@ package com.directors.infrastructure.jpa.room;
 
 import com.directors.domain.room.Room;
 import com.directors.domain.room.RoomRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.HashMap;
 import java.util.List;
@@ -10,13 +9,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Repository
 public class InmemeoryRoomRepository implements RoomRepository {
     Map<Long, Room> roomMap = new HashMap<>();
     private Long nextId = 1L;
 
     @Override
-    public Optional<Room> findByRoomId(Long roomId) {
+    public Optional<Room> findById(Long roomId) {
         return Optional.ofNullable(roomMap.get(roomId));
     }
 
@@ -29,22 +27,24 @@ public class InmemeoryRoomRepository implements RoomRepository {
     @Override
     public List<Room> findByDirectorId(String directorId) {
         return roomMap.values().stream()
-                .filter(room -> directorId.equals(room.getDirectorId()))
+                .filter(room -> directorId.equals(room.getDirector().getId()))
                 .collect(Collectors.toList());
     }
 
     @Override
     public List<Room> findByQuestionerId(String questionerId) {
         return roomMap.values().stream()
-                .filter(room -> questionerId.equals(room.getQuestionerId()))
+                .filter(room -> questionerId.equals(room.getQuestioner().getId()))
                 .collect(Collectors.toList());
     }
 
     @Override
-    public void save(Room room) {
+    public Room save(Room room) {
         if (room.getId() == null) {
             room.setId(nextId++);
         }
         roomMap.put(room.getId(), room);
+
+        return room;
     }
 }

--- a/src/main/java/com/directors/infrastructure/jpa/room/JpaRoomRepository.java
+++ b/src/main/java/com/directors/infrastructure/jpa/room/JpaRoomRepository.java
@@ -1,0 +1,15 @@
+package com.directors.infrastructure.jpa.room;
+
+import com.directors.domain.room.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface JpaRoomRepository extends JpaRepository<Room, Long> {
+    List<Room> findByDirectorId(String directorId);
+
+    List<Room> findByQuestionerId(String questionerId);
+
+    Optional<Room> findByQuestionId(Long questionId);
+}

--- a/src/main/java/com/directors/infrastructure/jpa/room/RoomRepositoryAdapter.java
+++ b/src/main/java/com/directors/infrastructure/jpa/room/RoomRepositoryAdapter.java
@@ -1,0 +1,40 @@
+package com.directors.infrastructure.jpa.room;
+
+import com.directors.domain.room.Room;
+import com.directors.domain.room.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RoomRepositoryAdapter implements RoomRepository {
+    private final JpaRoomRepository jpaRoomRepository;
+
+    @Override
+    public Optional<Room> findById(Long roomId) {
+        return jpaRoomRepository.findById(roomId);
+    }
+
+    @Override
+    public Optional<Room> findByQuestionId(Long questionId) {
+        return jpaRoomRepository.findByQuestionId(questionId);
+    }
+
+    @Override
+    public List<Room> findByDirectorId(String directorId) {
+        return jpaRoomRepository.findByDirectorId(directorId);
+    }
+
+    @Override
+    public List<Room> findByQuestionerId(String questionerId) {
+        return jpaRoomRepository.findByQuestionerId(questionerId);
+    }
+
+    @Override
+    public Room save(Room room) {
+        return jpaRoomRepository.save(room);
+    }
+}

--- a/src/main/java/com/directors/presentation/chat/ChatController.java
+++ b/src/main/java/com/directors/presentation/chat/ChatController.java
@@ -5,6 +5,10 @@ import com.directors.domain.chat.ChatRepository;
 import com.directors.domain.chat.LiveChatManager;
 import com.directors.domain.room.Room;
 import com.directors.domain.room.RoomRepository;
+import com.directors.domain.room.exception.RoomNotFoundException;
+import com.directors.domain.user.User;
+import com.directors.domain.user.UserRepository;
+import com.directors.domain.user.exception.NoSuchUserException;
 import com.directors.presentation.chat.request.SendChatRequest;
 import com.directors.presentation.chat.response.ChatListResponse;
 import jakarta.validation.Valid;
@@ -16,7 +20,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,6 +30,7 @@ import java.util.stream.Collectors;
 public class ChatController {
     private final ChatRepository chatRepository;
     private final RoomRepository roomRepository;
+    private final UserRepository userRepository;
     private final LiveChatManager liveChatManager;
 
     @GetMapping("/receiveStream/{roomId}")
@@ -48,9 +52,9 @@ public class ChatController {
     public ResponseEntity<HttpStatus> send(@Valid @RequestBody SendChatRequest request, @AuthenticationPrincipal String userByToken) {
         roomValidate(request.roomId(), userByToken);
 
-        saveChat(request.roomId(), request.chatContent(), userByToken);
-
         liveChatManager.sendMessage(request.roomId(), request.chatContent(), userByToken);
+
+        saveChat(request.roomId(), request.chatContent(), userByToken);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
@@ -69,12 +73,20 @@ public class ChatController {
     }
 
     private void roomValidate(Long roomId, String userId) {
-        Room room = roomRepository.findByRoomId(roomId).orElseThrow();
+        Room room = roomRepository.findById(roomId).orElseThrow();
         room.validateRoomUser(userId);
     }
 
     private void saveChat(Long roomId, String chatContent, String sendUserId) {
-        Chat chat = Chat.of(roomId, chatContent, sendUserId, LocalDateTime.now());
+        Room room = roomRepository
+                .findById(roomId)
+                .orElseThrow(() -> new RoomNotFoundException(roomId, sendUserId));
+        User user = userRepository
+                .findById(sendUserId)
+                .orElseThrow(() -> new NoSuchUserException(sendUserId));
+
+        Chat chat = Chat.of(room, chatContent, user);
+
         chatRepository.save(chat);
     }
 }

--- a/src/main/java/com/directors/presentation/chat/response/ChatListResponse.java
+++ b/src/main/java/com/directors/presentation/chat/response/ChatListResponse.java
@@ -11,6 +11,6 @@ public record ChatListResponse(
         LocalDateTime createTime
 ) {
     public static ChatListResponse from(Chat chat) {
-        return new ChatListResponse(chat.getRoomId(), chat.getContent(), chat.getSendUserId(), chat.getCreateTime());
+        return new ChatListResponse(chat.getRoom().getId(), chat.getContent(), chat.getSendUser().getId(), chat.getCreatedTime());
     }
 }


### PR DESCRIPTION
## PR 유형

- [ ] 버그 수정
- [x] 기능
- [ ] 코드 스타일
- [x] 리팩토링
- [ ] 빌드
- [ ] CI/CD
- [ ] 문서
- [ ] 기타
  <br>

## 변경사항

### 변경 전
- 채팅, 채팅방 도메인 객체를 메모리 상의 컬렉션을 통해 관리하고 있었습니다.

### 변경 후
- 위 도메인 객체를 JPA를 통해 관리하도록 코드를 수정했습니다.

close #36 