### PR TITLE
[#42] 유저 도메인 서비스, 레포지토리 단위 테스트

### DIFF
--- a/src/main/java/com/directors/application/user/SignUpService.java
+++ b/src/main/java/com/directors/application/user/SignUpService.java
@@ -4,6 +4,8 @@ import com.directors.domain.user.PasswordManager;
 import com.directors.domain.user.User;
 import com.directors.domain.user.UserRepository;
 import com.directors.domain.user.exception.DuplicateIdException;
+import com.directors.presentation.user.request.SignUpRequest;
+import com.directors.presentation.user.response.SignUpResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +18,14 @@ public class SignUpService {
     private final PasswordManager pm;
 
     @Transactional
-    public void signUp(User newUser) {
-        isDuplicatedUser(newUser.getId());
+    public SignUpResponse signUp(SignUpRequest signUpRequest) {
+        User user = signUpRequest.toEntity();
 
-        newUser.setPasswordByEncryption(pm.encryptPassword(newUser.getPassword()));
+        isDuplicatedUser(user.getId());
 
-        userRepository.save(newUser);
+        user.setPasswordByEncryption(pm.encryptPassword(user.getPassword()));
+
+        return SignUpResponse.of(userRepository.save(user));
     }
 
     @Transactional

--- a/src/main/java/com/directors/application/user/UpdateUserService.java
+++ b/src/main/java/com/directors/application/user/UpdateUserService.java
@@ -31,7 +31,6 @@ public class UpdateUserService {
         user.setPasswordByEncryption(encryptPassword);
     }
 
-
     @Transactional
     public void updateEmail(UpdateEmailRequest updateEmailRequest, String userIdByToken) {
         String oldEmail = updateEmailRequest.oldEmail();

--- a/src/main/java/com/directors/application/user/UpdateUserService.java
+++ b/src/main/java/com/directors/application/user/UpdateUserService.java
@@ -23,7 +23,7 @@ public class UpdateUserService {
         var oldPassword = updatePasswordRequest.oldPassword();
         var newPassword = updatePasswordRequest.newPassword();
 
-        var user = validateUser(userIdByToken);
+        var user = getUser(userIdByToken);
         validatePassword(oldPassword, user);
 
         String encryptPassword = passwordManager.encryptPassword(newPassword);
@@ -33,20 +33,18 @@ public class UpdateUserService {
 
     @Transactional
     public void updateEmail(UpdateEmailRequest updateEmailRequest, String userIdByToken) {
-        String oldEmail = updateEmailRequest.oldEmail();
         String newEmail = updateEmailRequest.newEmail();
 
-        var user = validateUser(userIdByToken);
+        var user = getUser(userIdByToken);
 
-        user.changeEmail(oldEmail, newEmail);
+        user.changeEmail(newEmail);
     }
 
-    private User validateUser(String userId) {
+    private User getUser(String userId) {
         return userRepository
                 .findByIdAndUserStatus(userId, UserStatus.JOINED)
                 .orElseThrow(() -> new AuthenticationFailedException(userId));
     }
-
 
     private void validatePassword(String password, User user) {
         if (!passwordManager.checkPassword(password, user.getPassword())) {

--- a/src/main/java/com/directors/application/user/WithdrawService.java
+++ b/src/main/java/com/directors/application/user/WithdrawService.java
@@ -6,6 +6,7 @@ import com.directors.domain.user.UserRepository;
 import com.directors.domain.user.UserStatus;
 import com.directors.domain.user.exception.AuthenticationFailedException;
 import com.directors.presentation.user.request.WithdrawRequest;
+import com.directors.presentation.user.response.WithdrawResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +22,7 @@ public class WithdrawService {
     private final TokenRepository tokenRepository;
 
     @Transactional
-    public void withdraw(WithdrawRequest withdrawRequest, String userIdByToken) {
+    public WithdrawResponse withdraw(WithdrawRequest withdrawRequest, String userIdByToken) {
         var userId = withdrawRequest.userId();
         var password = withdrawRequest.password();
 
@@ -35,6 +36,8 @@ public class WithdrawService {
         user.withdrawal(LocalDateTime.now());
 
         tokenRepository.deleteAllTokenByUserId(user.getId());
+
+        return new WithdrawResponse(userId);
     }
 
     private void validateUserIds(String firstUserId, String secondUserId) {

--- a/src/main/java/com/directors/application/user/WithdrawService.java
+++ b/src/main/java/com/directors/application/user/WithdrawService.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +32,7 @@ public class WithdrawService {
                 .filter(u -> pm.checkPassword(password, u.getPassword()))
                 .orElseThrow(() -> new AuthenticationFailedException(userId));
 
-        user.withdrawal(new Date());
+        user.withdrawal(LocalDateTime.now());
 
         tokenRepository.deleteAllTokenByUserId(user.getId());
     }

--- a/src/main/java/com/directors/domain/user/User.java
+++ b/src/main/java/com/directors/domain/user/User.java
@@ -5,7 +5,6 @@ import com.directors.domain.region.Address;
 import com.directors.domain.schedule.Schedule;
 import com.directors.domain.specialty.Specialty;
 import com.directors.domain.specialty.SpecialtyInfo;
-import com.directors.domain.user.exception.AuthenticationFailedException;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -74,19 +73,12 @@ public class User extends BaseEntity {
         this.password = encryptedPassword;
     }
 
-    public void changeEmail(String oldEmail, String newEmail) {
-        validateEmail(oldEmail);
+    public void changeEmail(String newEmail) {
         this.email = newEmail;
     }
 
     public void withdrawal(LocalDateTime withdrawalTime) {
         this.userStatus = UserStatus.WITHDRAWN;
         this.withdrawalDate = withdrawalDate;
-    }
-
-    private void validateEmail(String email) {
-        if (!this.email.equals(email)) {
-            throw new AuthenticationFailedException(this.id);
-        }
     }
 }

--- a/src/main/java/com/directors/domain/user/User.java
+++ b/src/main/java/com/directors/domain/user/User.java
@@ -11,7 +11,6 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,7 +39,7 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus;
 
-    private Date withdrawalDate;
+    private LocalDateTime withdrawalDate;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Specialty> specialtyList = new ArrayList<>();
@@ -80,7 +79,7 @@ public class User extends BaseEntity {
         this.email = newEmail;
     }
 
-    public void withdrawal(Date withdrawalDate) {
+    public void withdrawal(LocalDateTime withdrawalTime) {
         this.userStatus = UserStatus.WITHDRAWN;
         this.withdrawalDate = withdrawalDate;
     }

--- a/src/main/java/com/directors/infrastructure/api/ApiResponseValidator.java
+++ b/src/main/java/com/directors/infrastructure/api/ApiResponseValidator.java
@@ -1,0 +1,23 @@
+package com.directors.infrastructure.api;
+
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+public class ApiResponseValidator {
+    private static final String CertificationErrorString = "인증 정보가 존재하지 않습니다";
+    private static final String NotFoundErrorString = "검색결과가 존재하지 않습니다.";
+
+    public static boolean isCertificated(ResponseEntity<Map<String, Object>> response) {
+        if (response.getBody().get("errMsg").equals(CertificationErrorString)) {
+            return false;
+        }
+        return true;
+    }
+
+    public static void checkNotFound(ResponseEntity<Map<String, Object>> response) {
+        if (response.getBody().get("errMsg").equals(NotFoundErrorString)) {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/src/main/java/com/directors/infrastructure/api/RegionApiClientManager.java
+++ b/src/main/java/com/directors/infrastructure/api/RegionApiClientManager.java
@@ -5,11 +5,8 @@ import com.directors.domain.region.RegionApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
@@ -25,6 +22,10 @@ public class RegionApiClientManager implements RegionApiClient {
     private final RegionApiTokenProvider regionApiTokenProvider;
     private final ApiSender apiSender;
 
+    private final String regionOneDepth = "sido_nm";
+    private final String regionTwoDepth = "sgg_nm";
+    private final String regionThreeDepth = "emdong_nm";
+
     @Override
     public Address findRegionAddressByLocation(double latitude, double longitude) {
         var uri = UriComponentsBuilder
@@ -37,37 +38,24 @@ public class RegionApiClientManager implements RegionApiClient {
 
         var response = apiSender.send(HttpMethod.GET, uri);
 
-        recoverIfTokenUnvalidate(uri, response);
-        checkNotFound(response);
-
-        var result = getResultFromResponse(response);
-
-        String fullAddress = result.get("sido_nm") + " " + result.get("sgg_nm") + " " + result.get("emdong_nm");
-        String unitAddress = result.get("emdong_nm");
-
-        return new Address(fullAddress, unitAddress);
-    }
-
-    private void recoverIfTokenUnvalidate(UriComponents uri, ResponseEntity<Map<String, Object>> response) {
-        if (response.getBody().get("errMsg").equals("인증 정보가 존재하지 않습니다")) {
+        // TODO: 토큰 유효 기간 주기(2시간)에 맞추어 토큰을 새로 가져오는 스케줄링 로직이 필요. 현재는 토큰이 유효하지 않으면 토큰을 업데이트하도록 하고 있음.
+        if (!ApiResponseValidator.isCertificated(response)) {
             regionApiTokenProvider.fetchApiAccessTokenFromAPI();
             response = apiSender.send(HttpMethod.GET, uri);
-
-            if (response == null) {
-                throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR);
-            }
         }
+
+        ApiResponseValidator.checkNotFound(response);
+
+        return getAddressFromResponse(response);
     }
 
-    private void checkNotFound(ResponseEntity<Map<String, Object>> response) {
-        if (response.getBody().get("errMsg").equals("검색결과가 존재하지 않습니다.")) {
-            throw new IllegalArgumentException();
-        }
-    }
-
-    private Map<String, String> getResultFromResponse(ResponseEntity<Map<String, Object>> response) {
+    private Address getAddressFromResponse(ResponseEntity<Map<String, Object>> response) {
         var result = (ArrayList<Object>) response.getBody().get("result");
         var resultMap = (Map<String, String>) result.get(0);
-        return resultMap;
+
+        var fullAddress = resultMap.get(regionOneDepth) + " " + resultMap.get(regionTwoDepth) + " " + resultMap.get(regionThreeDepth);
+        var unitAddress = resultMap.get(regionThreeDepth);
+
+        return new Address(fullAddress, unitAddress);
     }
 }

--- a/src/main/java/com/directors/infrastructure/api/RegionApiClientManager.java
+++ b/src/main/java/com/directors/infrastructure/api/RegionApiClientManager.java
@@ -60,7 +60,7 @@ public class RegionApiClientManager implements RegionApiClient {
     }
 
     private void checkNotFound(ResponseEntity<Map<String, Object>> response) {
-        if (response.getBody().get("errMsg").equals("검색결과가 존재하지 않습니다")) {
+        if (response.getBody().get("errMsg").equals("검색결과가 존재하지 않습니다.")) {
             throw new IllegalArgumentException();
         }
     }

--- a/src/main/java/com/directors/infrastructure/api/RegionApiClientManager.java
+++ b/src/main/java/com/directors/infrastructure/api/RegionApiClientManager.java
@@ -2,7 +2,6 @@ package com.directors.infrastructure.api;
 
 import com.directors.domain.region.Address;
 import com.directors.domain.region.RegionApiClient;
-import com.directors.infrastructure.exception.api.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
@@ -61,8 +60,8 @@ public class RegionApiClientManager implements RegionApiClient {
     }
 
     private void checkNotFound(ResponseEntity<Map<String, Object>> response) {
-        if ((Integer) response.getBody().get("errCd") == -100) {
-            throw new NotFoundException();
+        if (response.getBody().get("errMsg").equals("검색결과가 존재하지 않습니다")) {
+            throw new IllegalArgumentException();
         }
     }
 

--- a/src/main/java/com/directors/infrastructure/auth/JwtAuthenticationManager.java
+++ b/src/main/java/com/directors/infrastructure/auth/JwtAuthenticationManager.java
@@ -1,6 +1,8 @@
 package com.directors.infrastructure.auth;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,7 +11,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
@@ -21,14 +22,6 @@ public class JwtAuthenticationManager {
 
     @Value("${jwtSecretKey}")
     private String secretKey;
-
-    public String generateAccessToken(String userId) {
-        return generateJwtTokenWithDay(userId, 1);
-    }
-
-    public String generateRefreshToken(String userId) {
-        return generateJwtTokenWithDay(userId, 30);
-    }
 
     public Authentication getAuthentication(String token) {
         String userId = getBodyByToken(token).getSubject();
@@ -52,19 +45,6 @@ public class JwtAuthenticationManager {
 
     private Key getSecretKey() {
         return Keys.hmacShaKeyFor(secretKey.getBytes());
-    }
-
-    private String generateJwtTokenWithDay(String userId, int day) throws JwtException {
-        Date now = new Date();
-
-        return Jwts.builder()
-                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setIssuer("directors.com")
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + Duration.ofDays(day).toMillis()))
-                .setSubject(userId)
-                .signWith(getSecretKey(), SignatureAlgorithm.HS256)
-                .compact();
     }
 
     private Claims getBodyByToken(String token) throws JwtException {

--- a/src/main/java/com/directors/infrastructure/auth/JwtTokenGenerator.java
+++ b/src/main/java/com/directors/infrastructure/auth/JwtTokenGenerator.java
@@ -1,0 +1,45 @@
+package com.directors.infrastructure.auth;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.Duration;
+import java.util.Date;
+
+@Component
+public class JwtTokenGenerator {
+
+    @Value("${jwtSecretKey}")
+    private String secretKey;
+
+    public String generateAccessToken(String userId) {
+        return generateJwtTokenWithDay(userId, 1);
+    }
+
+    public String generateRefreshToken(String userId) {
+        return generateJwtTokenWithDay(userId, 30);
+    }
+
+    public String generateJwtTokenWithDay(String userId, int day) throws JwtException {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuer("directors.com")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + Duration.ofDays(day).toMillis()))
+                .setSubject(userId)
+                .signWith(getSecretKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private Key getSecretKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+}

--- a/src/main/java/com/directors/infrastructure/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/directors/infrastructure/exception/GlobalExceptionHandler.java
@@ -10,9 +10,6 @@ import com.directors.domain.user.exception.AuthenticationFailedException;
 import com.directors.domain.user.exception.DuplicateIdException;
 import com.directors.domain.user.exception.NoSuchUserException;
 import com.directors.domain.user.exception.UserRegionNotFoundException;
-import com.directors.infrastructure.exception.api.ExteralApiAuthenticationException;
-import com.directors.infrastructure.exception.api.ExternalApiServerException;
-import com.directors.infrastructure.exception.api.NotFoundException;
 import com.directors.infrastructure.exception.api.RenewApiKeyException;
 import com.directors.infrastructure.exception.common.EntityNotFoundException;
 import com.directors.infrastructure.exception.question.InvalidQuestionStatusException;
@@ -47,9 +44,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * 이를 오버라이드하여 구현했습니다.
      */
     @Override
-    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e,
                                                                   HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        BindingResult bindingResult = ex.getBindingResult();
+        BindingResult bindingResult = e.getBindingResult();
         return new ResponseEntity<>(new ErrorMessage(bindingResult.getFieldErrors().get(0).getDefaultMessage()),
                 HttpStatus.BAD_REQUEST);
     }
@@ -77,14 +74,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(JwtException.class)
-    public ErrorMessage JwtExceptionHandler(JwtException e) {
+    public ErrorMessage JwtExceptionHandler() {
         log.info("JwtException occurred.");
         return new ErrorMessage("유효하지 않은 토큰입니다.");
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<HttpStatus> IllegalArgumentExceptionHandler(IllegalArgumentException e) {
+    public ResponseEntity<HttpStatus> illegalArgumentExceptionHandler() {
         log.info("IllegalArgumentException occurred.");
         return new ResponseEntity(HttpStatus.BAD_REQUEST);
     }
@@ -113,9 +110,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
     @ExceptionHandler(HttpClientErrorException.class)
-    public ErrorMessage httpClientErrorException(HttpClientErrorException ex) {
-        String errorMessage = "HttpClientErrorException occurred. " + ex.getStatusCode();
-        if (ex.getStatusCode().equals("412 PRECONDITION_FAILED")) {
+    public ErrorMessage httpClientErrorException(HttpClientErrorException e) {
+        String errorMessage = "HttpClientErrorException occurred. " + e.getStatusCode();
+        if (e.getStatusCode().equals("412 PRECONDITION_FAILED")) {
             errorMessage += "need to check api request parameter.";
         }
 
@@ -124,36 +121,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
-    @ExceptionHandler(ExteralApiAuthenticationException.class)
-    public ErrorMessage exteralApiAuthenticationException(ExteralApiAuthenticationException ex) {
-        log.error("ExteralApiAuthenticationException occurred. " + ex.getMessage());
-        return new ErrorMessage("잠시 후 다시 시도해주세요");
-    }
-
-    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
     @ExceptionHandler(HttpServerErrorException.class)
-    public ErrorMessage httpServerErrorException(HttpServerErrorException ex) {
-        log.error("HttpServerErrorException occurred. " + ex.getStatusCode());
-        return new ErrorMessage("잠시 후 다시 시도해주세요");
-    }
-
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    @ExceptionHandler(NotFoundException.class)
-    public ErrorMessage notFoundException(NotFoundException ex) {
-        log.info("NotFoundException occurred.");
-        return new ErrorMessage(ex.getMessage());
-    }
-
-    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
-    @ExceptionHandler(ExternalApiServerException.class)
-    public ErrorMessage externalApiServerException(NotFoundException ex) {
-        log.warn("ExternalApiServerException occurred. An exception occurred in the sgis server.");
+    public ErrorMessage httpServerErrorException(HttpServerErrorException e) {
+        log.error("HttpServerErrorException occurred. " + e.getStatusCode());
         return new ErrorMessage("잠시 후 다시 시도해주세요");
     }
 
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
     @ExceptionHandler(RenewApiKeyException.class)
-    public ErrorMessage externalApiServerException(RenewApiKeyException ex) {
+    public ErrorMessage renewApiKeyException() {
         log.error("RenewApiKeyException occurred. API key renewal is required.");
         return new ErrorMessage("잠시 후 다시 시도해주세요");
     }
@@ -179,16 +155,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(NoSuchSpecialtyException.class)
-    public ErrorMessage noSuchSpecialtyException(NoSuchSpecialtyException ex) {
+    public ErrorMessage noSuchSpecialtyException(NoSuchSpecialtyException e) {
         log.warn("NoSuchSpecialtyException occurred.");
-        return new ErrorMessage(ex.getMessage());
+        return new ErrorMessage(e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(UserRegionNotFoundException.class)
-    public ErrorMessage userRegionNotFoundException(UserRegionNotFoundException ex) {
-        log.warn("UserRegionNotFoundException occurred. requestedUserId: " + ex.requestedUserId);
-        return new ErrorMessage(ex.getMessage());
+    public ErrorMessage userRegionNotFoundException(UserRegionNotFoundException e) {
+        log.warn("UserRegionNotFoundException occurred. requestedUserId: " + e.requestedUserId);
+        return new ErrorMessage(e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.CONFLICT)

--- a/src/main/java/com/directors/infrastructure/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/directors/infrastructure/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import com.directors.domain.user.exception.UserRegionNotFoundException;
 import com.directors.infrastructure.exception.api.ExteralApiAuthenticationException;
 import com.directors.infrastructure.exception.api.ExternalApiServerException;
 import com.directors.infrastructure.exception.api.NotFoundException;
+import com.directors.infrastructure.exception.api.RenewApiKeyException;
 import com.directors.infrastructure.exception.common.EntityNotFoundException;
 import com.directors.infrastructure.exception.question.InvalidQuestionStatusException;
 import com.directors.infrastructure.exception.question.QuestionDuplicateException;
@@ -147,6 +148,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ExternalApiServerException.class)
     public ErrorMessage externalApiServerException(NotFoundException ex) {
         log.warn("ExternalApiServerException occurred. An exception occurred in the sgis server.");
+        return new ErrorMessage("잠시 후 다시 시도해주세요");
+    }
+
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    @ExceptionHandler(RenewApiKeyException.class)
+    public ErrorMessage externalApiServerException(RenewApiKeyException ex) {
+        log.error("RenewApiKeyException occurred. API key renewal is required.");
         return new ErrorMessage("잠시 후 다시 시도해주세요");
     }
 

--- a/src/main/java/com/directors/infrastructure/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/directors/infrastructure/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import com.directors.domain.user.exception.UserRegionNotFoundException;
 import com.directors.infrastructure.exception.api.ExteralApiAuthenticationException;
 import com.directors.infrastructure.exception.api.ExternalApiServerException;
 import com.directors.infrastructure.exception.api.NotFoundException;
+import com.directors.infrastructure.exception.common.EntityNotFoundException;
 import com.directors.infrastructure.exception.question.InvalidQuestionStatusException;
 import com.directors.infrastructure.exception.question.QuestionDuplicateException;
 import com.directors.infrastructure.exception.question.QuestionNotFoundException;
@@ -215,6 +216,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(FeedbackNotFoundException.class)
     public ErrorMessage feedbackNotFoundException(FeedbackNotFoundException e) {
         log.info("FeedbackNotFoundException occurred. " + "feedbackId = " + e.getFeedbackId());
+        return new ErrorMessage(e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ErrorMessage entityNotFoundException(EntityNotFoundException e) {
+        log.info("EntityNotFoundException occurred.");
         return new ErrorMessage(e.getMessage());
     }
 }

--- a/src/main/java/com/directors/infrastructure/exception/api/ExteralApiAuthenticationException.java
+++ b/src/main/java/com/directors/infrastructure/exception/api/ExteralApiAuthenticationException.java
@@ -1,7 +1,0 @@
-package com.directors.infrastructure.exception.api;
-
-public class ExteralApiAuthenticationException extends RuntimeException {
-    public ExteralApiAuthenticationException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/directors/infrastructure/exception/api/ExternalApiServerException.java
+++ b/src/main/java/com/directors/infrastructure/exception/api/ExternalApiServerException.java
@@ -1,4 +1,0 @@
-package com.directors.infrastructure.exception.api;
-
-public class ExternalApiServerException extends RuntimeException {
-}

--- a/src/main/java/com/directors/infrastructure/exception/api/NotFoundException.java
+++ b/src/main/java/com/directors/infrastructure/exception/api/NotFoundException.java
@@ -1,9 +1,0 @@
-package com.directors.infrastructure.exception.api;
-
-public class NotFoundException extends RuntimeException {
-    private final static String message = "검색 결과가 존재하지 않습니다.";
-
-    public NotFoundException() {
-        super(message);
-    }
-}

--- a/src/main/java/com/directors/infrastructure/exception/api/RenewApiKeyException.java
+++ b/src/main/java/com/directors/infrastructure/exception/api/RenewApiKeyException.java
@@ -1,0 +1,4 @@
+package com.directors.infrastructure.exception.api;
+
+public class RenewApiKeyException extends RuntimeException {
+}

--- a/src/main/java/com/directors/infrastructure/exception/common/EntityNotFoundException.java
+++ b/src/main/java/com/directors/infrastructure/exception/common/EntityNotFoundException.java
@@ -1,0 +1,12 @@
+package com.directors.infrastructure.exception.common;
+
+import com.directors.infrastructure.exception.ExceptionCode;
+
+public class EntityNotFoundException extends RuntimeException {
+    private final ExceptionCode exceptionCode;
+
+    public EntityNotFoundException(ExceptionCode exceptionCode) {
+        super();
+        this.exceptionCode = exceptionCode;
+    }
+}

--- a/src/main/java/com/directors/presentation/user/UserController.java
+++ b/src/main/java/com/directors/presentation/user/UserController.java
@@ -59,9 +59,8 @@ public class UserController {
     }
 
     @PostMapping("/withdraw")
-    public ResponseEntity<HttpStatus> withdraw(@Valid @RequestBody WithdrawRequest withdrawRequest, @AuthenticationPrincipal String userIdByToken) {
-        withdrawService.withdraw(withdrawRequest, userIdByToken);
-        return new ResponseEntity<>(HttpStatus.OK);
+    public ResponseEntity<WithdrawResponse> withdraw(@Valid @RequestBody WithdrawRequest withdrawRequest, @AuthenticationPrincipal String userIdByToken) {
+        return new ResponseEntity<>(withdrawService.withdraw(withdrawRequest, userIdByToken), HttpStatus.OK);
     }
 
     @PostMapping("/updatePassword")

--- a/src/main/java/com/directors/presentation/user/UserController.java
+++ b/src/main/java/com/directors/presentation/user/UserController.java
@@ -29,9 +29,8 @@ public class UserController {
     private final SearchDirectorService searchDiretorService;
 
     @PostMapping("/signUp")
-    public ResponseEntity<HttpStatus> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
-        signUpService.signUp(signUpRequest.toEntity());
-        return new ResponseEntity<>(HttpStatus.CREATED);
+    public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
+        return new ResponseEntity<>(signUpService.signUp(signUpRequest), HttpStatus.CREATED);
     }
 
     @GetMapping("/duplicated/{id}")

--- a/src/main/java/com/directors/presentation/user/request/AuthenticateRegionRequest.java
+++ b/src/main/java/com/directors/presentation/user/request/AuthenticateRegionRequest.java
@@ -1,10 +1,16 @@
 package com.directors.presentation.user.request;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 
 @Builder
 public record AuthenticateRegionRequest(
+        @NotNull
+        @Positive
         double latitude,
+        @NotNull
+        @Positive
         double longitude
 ) {
 }

--- a/src/main/java/com/directors/presentation/user/request/AuthenticateRegionRequest.java
+++ b/src/main/java/com/directors/presentation/user/request/AuthenticateRegionRequest.java
@@ -1,5 +1,8 @@
 package com.directors.presentation.user.request;
 
+import lombok.Builder;
+
+@Builder
 public record AuthenticateRegionRequest(
         double latitude,
         double longitude

--- a/src/main/java/com/directors/presentation/user/request/LogInRequest.java
+++ b/src/main/java/com/directors/presentation/user/request/LogInRequest.java
@@ -1,7 +1,9 @@
 package com.directors.presentation.user.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record LogInRequest(
         @NotBlank(message = "아이디가 입력되지 않았습니다.")
         String userId,

--- a/src/main/java/com/directors/presentation/user/request/SignUpRequest.java
+++ b/src/main/java/com/directors/presentation/user/request/SignUpRequest.java
@@ -5,7 +5,9 @@ import com.directors.domain.user.UserStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record SignUpRequest(
         @NotBlank(message = "아이디가 입력되지 않았습니다.")
         @Size(min = 8, max = 20, message = "아이디의 길이가 8-20글자 사이로 입력되지 않았습니다.")

--- a/src/main/java/com/directors/presentation/user/request/UpdateEmailRequest.java
+++ b/src/main/java/com/directors/presentation/user/request/UpdateEmailRequest.java
@@ -4,9 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record UpdateEmailRequest(
-        @NotBlank(message = "기존 이메일이 입력되지 않았습니다.")
-        @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "올바른 이메일 형식이 아닙니다.")
-        String oldEmail,
         @NotBlank(message = "새 이메일이 입력되지 않았습니다.")
         @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "올바른 이메일 형식이 아닙니다.")
         String newEmail

--- a/src/main/java/com/directors/presentation/user/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/directors/presentation/user/request/UpdatePasswordRequest.java
@@ -2,7 +2,9 @@ package com.directors.presentation.user.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record UpdatePasswordRequest(
         @NotBlank(message = "기존 패스워드가 입력되지 않았습니다.")
         @Size(min = 8, max = 20, message = "기존 패스워드의 길이가 8-20글자 사이로 입력되지 않았습니다.")

--- a/src/main/java/com/directors/presentation/user/request/WithdrawRequest.java
+++ b/src/main/java/com/directors/presentation/user/request/WithdrawRequest.java
@@ -1,7 +1,9 @@
 package com.directors.presentation.user.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record WithdrawRequest(
         @NotBlank(message = "아이디가 입력되지 않았습니다.")
         String userId,

--- a/src/main/java/com/directors/presentation/user/response/SignUpResponse.java
+++ b/src/main/java/com/directors/presentation/user/response/SignUpResponse.java
@@ -1,0 +1,23 @@
+package com.directors.presentation.user.response;
+
+import com.directors.domain.user.User;
+import lombok.Builder;
+
+@Builder
+public record SignUpResponse(
+        String id,
+        String name,
+        String nickname,
+        String email,
+        String phoneNumber
+) {
+    public static SignUpResponse of(User user) {
+        return SignUpResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/directors/presentation/user/response/WithdrawResponse.java
+++ b/src/main/java/com/directors/presentation/user/response/WithdrawResponse.java
@@ -1,0 +1,6 @@
+package com.directors.presentation.user.response;
+
+public record WithdrawResponse(
+        String userId
+) {
+}

--- a/src/test/java/com/directors/application/feedback/FeedbackServiceTest.java
+++ b/src/test/java/com/directors/application/feedback/FeedbackServiceTest.java
@@ -1,7 +1,6 @@
 package com.directors.application.feedback;
 
 import com.directors.IntegrationTestSupport;
-import com.directors.domain.feedback.FeedbackRepository;
 import com.directors.domain.feedback.exception.CannotCreateFeedbackException;
 import com.directors.domain.feedback.exception.FeedbackNotFoundException;
 import com.directors.domain.question.Question;
@@ -32,16 +31,10 @@ class FeedbackServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private QuestionRepository questionRepository;
-
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private FeedbackRepository feedbackRepository;
-
     @Autowired
     private ScheduleRepository scheduleRepository;
-
     @Autowired
     FeedbackService feedbackService;
 

--- a/src/test/java/com/directors/application/user/AuthenticateRegionServiceTest.java
+++ b/src/test/java/com/directors/application/user/AuthenticateRegionServiceTest.java
@@ -1,0 +1,77 @@
+package com.directors.application.user;
+
+import com.directors.domain.region.Address;
+import com.directors.domain.region.RegionApiClient;
+import com.directors.presentation.user.request.AuthenticateRegionRequest;
+import com.directors.presentation.user.request.SignUpRequest;
+import com.directors.presentation.user.response.AuthenticateRegionResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class AuthenticateRegionServiceTest extends UserTestSupport {
+
+    @MockBean
+    public RegionApiClient regionApiClient;
+
+    @DisplayName("위도와 경도 정보를 통해 유저의 지역을 인증한다.")
+    @Test
+    void authenticate() {
+        // given
+        String givenUserId = "cnsong1234";
+        double givenLatitude = 961487;
+        double givenLongitude = 1949977;
+        String givenFullAddress = "서울특별시 성동구 송정동";
+        String givenUnitAddress = "송정동";
+
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        AuthenticateRegionRequest request = AuthenticateRegionRequest.builder()
+                .latitude(givenLatitude)
+                .longitude(givenLongitude)
+                .build();
+
+        when(regionApiClient.findRegionAddressByLocation(any(Double.class), any(Double.class)))
+                .thenReturn(new Address(givenFullAddress, givenUnitAddress));
+
+        // when
+        AuthenticateRegionResponse response = authenticateRegionService.authenticate(request, givenUserId);
+
+        // then
+        assertThat(response)
+                .extracting("fullAddress", "unitAddress")
+                .contains(givenFullAddress, givenUnitAddress);
+    }
+
+    @DisplayName("한국 행정 구역 내에 있지 않은 위치의 위도와 경도 정보로 지역 인증을 시도할 경우 예외를 발생시킨다.")
+    @Test
+    void authenticateWithOutOfBoundary() {
+        // given
+        String givenUserId = "cnsong1234";
+        double givenLatitude = 1;
+        double givenLongitude = 1;
+
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        AuthenticateRegionRequest request = AuthenticateRegionRequest.builder()
+                .latitude(givenLatitude)
+                .longitude(givenLongitude)
+                .build();
+
+        when(regionApiClient.findRegionAddressByLocation(any(Double.class), any(Double.class)))
+                .thenThrow(IllegalArgumentException.class);
+
+        // when then
+        assertThatThrownBy(() -> authenticateRegionService.authenticate(request, givenUserId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/directors/application/user/LogInTest.java
+++ b/src/test/java/com/directors/application/user/LogInTest.java
@@ -1,17 +1,13 @@
 package com.directors.application.user;
 
-import com.directors.IntegrationTestSupport;
 import com.directors.domain.user.User;
-import com.directors.domain.user.UserRepository;
 import com.directors.domain.user.UserStatus;
 import com.directors.domain.user.exception.AuthenticationFailedException;
-import com.directors.infrastructure.auth.JwtAuthenticationManager;
 import com.directors.presentation.user.request.LogInRequest;
 import com.directors.presentation.user.request.SignUpRequest;
 import com.directors.presentation.user.response.LogInResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 
 import java.time.LocalDateTime;
@@ -19,19 +15,7 @@ import java.time.LocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class LogInTest extends IntegrationTestSupport {
-
-    @Autowired
-    private AuthenticationService authenticationService;
-
-    @Autowired
-    private SignUpService signUpService;
-
-    @Autowired
-    private JwtAuthenticationManager jwtAuthenticationManager;
-
-    @Autowired
-    private UserRepository userRepository;
+class LogInTest extends UserTestSupport {
 
     @DisplayName("아이디와 패스워드를 통해 로그인을 한다.")
     @Test

--- a/src/test/java/com/directors/application/user/LogInTest.java
+++ b/src/test/java/com/directors/application/user/LogInTest.java
@@ -1,0 +1,126 @@
+package com.directors.application.user;
+
+import com.directors.IntegrationTestSupport;
+import com.directors.domain.user.User;
+import com.directors.domain.user.UserRepository;
+import com.directors.domain.user.UserStatus;
+import com.directors.domain.user.exception.AuthenticationFailedException;
+import com.directors.infrastructure.auth.JwtAuthenticationManager;
+import com.directors.presentation.user.request.LogInRequest;
+import com.directors.presentation.user.request.SignUpRequest;
+import com.directors.presentation.user.response.LogInResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LogInTest extends IntegrationTestSupport {
+
+    @Autowired
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private SignUpService signUpService;
+
+    @Autowired
+    private JwtAuthenticationManager jwtAuthenticationManager;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("아이디와 패스워드를 통해 로그인을 한다.")
+    @Test
+    void logIn() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper.createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        LogInRequest loginRequest = UserTestHelper.createLogInRequest(givenUserId, "1234567890");
+
+        // when
+        LogInResponse logInResponse = authenticationService.logIn(loginRequest);
+
+        // then
+        assertThat(logInResponse).isNotNull();
+        assertThat(logInResponse.accessToken()).isNotBlank();
+        assertThat(logInResponse.refreshToken()).isNotBlank();
+
+        // access token validation
+        String accessToken = logInResponse.accessToken();
+        Authentication authenticationByAccessToken = jwtAuthenticationManager.getAuthentication(accessToken);
+
+        String accessPrincipal = (String) authenticationByAccessToken.getPrincipal();
+        long expirationDayByAccessToken = jwtAuthenticationManager.getExpirationDayByToken(accessToken);
+
+        assertThat(accessPrincipal).isEqualTo(givenUserId);
+        assertThat(expirationDayByAccessToken).isEqualTo(0);
+
+        // refresh token validation
+        String refreshToken = logInResponse.refreshToken();
+        Authentication authenticationByRefreshToken = jwtAuthenticationManager.getAuthentication(refreshToken);
+        String refreshPrincipal = (String) authenticationByRefreshToken.getPrincipal();
+        long expirationDayByRefreshToken = jwtAuthenticationManager.getExpirationDayByToken(refreshToken);
+
+        assertThat(refreshPrincipal).isEqualTo(givenUserId);
+        assertThat(expirationDayByRefreshToken).isEqualTo(29);
+    }
+
+    @DisplayName("회원 가입되지 않은 아이디를 통해 로그인을 하면 인증 예외가 발생한다.")
+    @Test
+    void logInWithWrongId() {
+        // given
+        LogInRequest givenLoginRequest = UserTestHelper.createLogInRequest("cnsong1234", "1234567890");
+
+        // when then
+        assertThatThrownBy(() -> authenticationService.logIn(givenLoginRequest))
+                .isInstanceOf(AuthenticationFailedException.class)
+                .hasMessage("유저 인증이 실패했습니다.");
+    }
+
+    @DisplayName("잘못된 비밀번호를 통해 로그인을 하면 인증 예외가 발생한다.")
+    @Test
+    void logInWithWrongPassword() {
+        // given
+        String givenUserId = "cnsong1234";
+        String givenPassword = "1234567890";
+
+        SignUpRequest signUpRequest = UserTestHelper.createSignUpRequest(givenUserId, givenPassword, "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        LogInRequest givenLoginRequest = UserTestHelper.createLogInRequest(givenUserId, givenPassword + "1");
+
+        // when then
+        assertThatThrownBy(() -> authenticationService.logIn(givenLoginRequest))
+                .isInstanceOf(AuthenticationFailedException.class)
+                .hasMessage("유저 인증이 실패했습니다.");
+    }
+
+    @DisplayName("탈퇴한 계정의 아이디와 비밀번호를 통해 로그인을 하면 인증 예외가 발생한다.")
+    @Test
+    void logInWithWithdrawlAccount() {
+        // given
+        String givenUserId = "cnsong1234";
+        String givenPassword = "1234567890";
+        SignUpRequest signUpRequest = UserTestHelper.createSignUpRequest(givenUserId, givenPassword, "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        User user = userRepository
+                .findByIdAndUserStatus(givenUserId, UserStatus.JOINED)
+                .orElseThrow(null);
+
+        user.withdrawal(LocalDateTime.now());
+
+        LogInRequest givenLoginRequest = UserTestHelper.createLogInRequest(givenUserId, givenPassword);
+
+        // when then
+        assertThatThrownBy(() -> authenticationService.logIn(givenLoginRequest))
+                .isInstanceOf(AuthenticationFailedException.class)
+                .hasMessage("유저 인증이 실패했습니다.");
+    }
+}

--- a/src/test/java/com/directors/application/user/LogOutTest.java
+++ b/src/test/java/com/directors/application/user/LogOutTest.java
@@ -1,0 +1,98 @@
+package com.directors.application.user;
+
+import com.directors.IntegrationTestSupport;
+import com.directors.domain.auth.Token;
+import com.directors.domain.auth.TokenRepository;
+import com.directors.infrastructure.auth.JwtTokenGenerator;
+import com.directors.presentation.user.request.LogInRequest;
+import com.directors.presentation.user.request.LogOutRequest;
+import com.directors.presentation.user.request.SignUpRequest;
+import com.directors.presentation.user.response.LogInResponse;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class LogOutTest extends IntegrationTestSupport {
+
+    @Autowired
+    private SignUpService signUpService;
+
+    @Autowired
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Autowired
+    private JwtTokenGenerator tokenGenerator;
+
+    @DisplayName("로그아웃 성공 시 유저의 모든 토큰 데이터가 삭제된다.")
+    @Test
+    void logOut() {
+        // given
+        SignUpRequest signUpRequest = UserTestHelper.createSignUpRequest("cnsong1234", "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+        LogInRequest loginRequest = UserTestHelper.createLogInRequest("cnsong1234", "1234567890");
+
+        LogInResponse logInResponse = authenticationService.logIn(loginRequest);
+        String refreshToken = logInResponse.refreshToken();
+
+        LogOutRequest logOutRequest = new LogOutRequest(refreshToken);
+
+        // when
+        authenticationService.logOut(logOutRequest);
+
+        // then
+        boolean tokenPresent = tokenRepository.findTokenByTokenString(refreshToken).isPresent();
+        assertThat(tokenPresent).isFalse();
+    }
+
+    @DisplayName("잘못된 리프레시 토큰을 통해 로그아웃하면 인증 예외가 발생한다.")
+    @Test
+    void logOutWithWrongRefreshToken() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper.createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+        LogInRequest loginRequest = UserTestHelper.createLogInRequest(givenUserId, "1234567890");
+
+        LogInResponse logInResponse = authenticationService.logIn(loginRequest);
+        String refreshToken = logInResponse.refreshToken();
+
+        LogOutRequest logOutRequest = new LogOutRequest(refreshToken + "1");
+
+        // when then
+        assertThatThrownBy(() -> authenticationService.logOut(logOutRequest))
+                .isInstanceOf(JwtException.class)
+                .hasMessage("유효하지 않은 토큰입니다.");
+    }
+
+    @DisplayName("유효기간이 지난 리프레시 토큰을 통해 로그아웃하면 인증 예외가 발생한다.")
+    @Test
+    void logOutWithExpiredRefreshToken() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper.createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+        LogInRequest loginRequest = UserTestHelper.createLogInRequest(givenUserId, "1234567890");
+
+        String expiredRefreshToken = tokenGenerator.generateJwtTokenWithDay(givenUserId, 0);
+
+        Token token = new Token(expiredRefreshToken, givenUserId, new Date());
+        tokenRepository.saveToken(token);
+
+        LogOutRequest logOutRequest = new LogOutRequest(expiredRefreshToken);
+
+        // when then
+        assertThatThrownBy(() -> authenticationService.logOut(logOutRequest))
+                .isInstanceOf(ExpiredJwtException.class)
+                .hasMessageContaining("JWT expired at");
+    }
+}

--- a/src/test/java/com/directors/application/user/LogOutTest.java
+++ b/src/test/java/com/directors/application/user/LogOutTest.java
@@ -1,9 +1,6 @@
 package com.directors.application.user;
 
-import com.directors.IntegrationTestSupport;
 import com.directors.domain.auth.Token;
-import com.directors.domain.auth.TokenRepository;
-import com.directors.infrastructure.auth.JwtTokenGenerator;
 import com.directors.presentation.user.request.LogInRequest;
 import com.directors.presentation.user.request.LogOutRequest;
 import com.directors.presentation.user.request.SignUpRequest;
@@ -12,26 +9,13 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class LogOutTest extends IntegrationTestSupport {
-
-    @Autowired
-    private SignUpService signUpService;
-
-    @Autowired
-    private AuthenticationService authenticationService;
-
-    @Autowired
-    private TokenRepository tokenRepository;
-
-    @Autowired
-    private JwtTokenGenerator tokenGenerator;
+public class LogOutTest extends UserTestSupport {
 
     @DisplayName("로그아웃 성공 시 유저의 모든 토큰 데이터가 삭제된다.")
     @Test

--- a/src/test/java/com/directors/application/user/RefreshAuthenticationTest.java
+++ b/src/test/java/com/directors/application/user/RefreshAuthenticationTest.java
@@ -1,0 +1,132 @@
+package com.directors.application.user;
+
+import com.directors.IntegrationTestSupport;
+import com.directors.infrastructure.auth.JwtAuthenticationManager;
+import com.directors.infrastructure.auth.JwtTokenGenerator;
+import com.directors.presentation.user.request.LogInRequest;
+import com.directors.presentation.user.request.RefreshAuthenticationRequest;
+import com.directors.presentation.user.request.SignUpRequest;
+import com.directors.presentation.user.response.LogInResponse;
+import com.directors.presentation.user.response.RefreshAuthenticationResponse;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class RefreshAuthenticationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private SignUpService signUpService;
+
+    @Autowired
+    private JwtAuthenticationManager jwtAuthenticationManager;
+
+    @Autowired
+    private JwtTokenGenerator tokenGenerator;
+
+    @DisplayName("액세스 토큰과 리프레시 토큰을 통해 토큰을 재발급받는다.")
+    @Test
+    void refreshAuthentication() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper.createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+        LogInRequest loginRequest = UserTestHelper.createLogInRequest(givenUserId, "1234567890");
+
+        LogInResponse logInResponse = authenticationService.logIn(loginRequest);
+
+        RefreshAuthenticationRequest request = new RefreshAuthenticationRequest(logInResponse.accessToken(), logInResponse.refreshToken());
+
+        // when
+        RefreshAuthenticationResponse response = authenticationService.refreshAuthentication(request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.accessToken()).isNotBlank();
+        assertThat(response.refreshToken()).isNotBlank();
+
+        // access token validation
+        String accessToken = logInResponse.accessToken();
+        Authentication authenticationByAccessToken = jwtAuthenticationManager.getAuthentication(accessToken);
+
+        String accessPrincipal = (String) authenticationByAccessToken.getPrincipal();
+        long expirationDayByAccessToken = jwtAuthenticationManager.getExpirationDayByToken(accessToken);
+
+        assertThat(accessPrincipal).isEqualTo(givenUserId);
+        assertThat(expirationDayByAccessToken).isEqualTo(0);
+
+        // refresh token validation
+        String refreshToken = logInResponse.refreshToken();
+        Authentication authenticationByRefreshToken = jwtAuthenticationManager.getAuthentication(refreshToken);
+        String refreshPrincipal = (String) authenticationByRefreshToken.getPrincipal();
+        long expirationDayByRefreshToken = jwtAuthenticationManager.getExpirationDayByToken(refreshToken);
+
+        assertThat(refreshPrincipal).isEqualTo(givenUserId);
+        assertThat(expirationDayByRefreshToken).isEqualTo(29);
+    }
+
+    @DisplayName("잘못된 내용의 토큰을 통해 토큰을 재발급하려고 하면 예외가 발생한다.")
+    @Test
+    void refreshAuthenticationWithWrongTokens() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+        LogInRequest loginRequest = UserTestHelper.createLogInRequest(givenUserId, "1234567890");
+
+        LogInResponse logInResponse = authenticationService.logIn(loginRequest);
+
+        RefreshAuthenticationRequest request = new RefreshAuthenticationRequest(logInResponse.accessToken() + "1", logInResponse.refreshToken() + "2");
+
+        // when then
+        assertThatThrownBy(() -> authenticationService.refreshAuthentication(request))
+                .isInstanceOf(JwtException.class)
+                .hasMessage("JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.");
+    }
+
+    @DisplayName("유효기간이 지난 토큰을 통해 토큰을 재발급하려고 하면 예외가 발생한다.")
+    @Test
+    void refreshAuthenticationWithExpiredToken() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        String expiredAccessToken = tokenGenerator.generateJwtTokenWithDay(givenUserId, 0);
+        String expiredRefreshToken = tokenGenerator.generateJwtTokenWithDay(givenUserId, 6);
+        RefreshAuthenticationRequest request = new RefreshAuthenticationRequest(expiredAccessToken, expiredRefreshToken);
+
+        // when then
+        assertThatThrownBy(() -> authenticationService.refreshAuthentication(request))
+                .isInstanceOf(JwtException.class)
+                .hasMessageContaining("JWT expired at");
+    }
+
+    @DisplayName("로그인 상태가 아닌 채로 토큰을 재발급하려고 하면 예외가 발생한다.")
+    @Test
+    void refreshAuthenticationWithOutLogin() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        String expiredAccessToken = tokenGenerator.generateJwtTokenWithDay(givenUserId, 2);
+        String expiredRefreshToken = tokenGenerator.generateJwtTokenWithDay(givenUserId, 8);
+        RefreshAuthenticationRequest request = new RefreshAuthenticationRequest(expiredAccessToken, expiredRefreshToken);
+
+        // when then
+        assertThatThrownBy(() -> authenticationService.refreshAuthentication(request))
+                .isInstanceOf(JwtException.class)
+                .hasMessage("유효하지 않은 토큰입니다.");
+    }
+}

--- a/src/test/java/com/directors/application/user/RefreshAuthenticationTest.java
+++ b/src/test/java/com/directors/application/user/RefreshAuthenticationTest.java
@@ -1,8 +1,5 @@
 package com.directors.application.user;
 
-import com.directors.IntegrationTestSupport;
-import com.directors.infrastructure.auth.JwtAuthenticationManager;
-import com.directors.infrastructure.auth.JwtTokenGenerator;
 import com.directors.presentation.user.request.LogInRequest;
 import com.directors.presentation.user.request.RefreshAuthenticationRequest;
 import com.directors.presentation.user.request.SignUpRequest;
@@ -11,25 +8,12 @@ import com.directors.presentation.user.response.RefreshAuthenticationResponse;
 import io.jsonwebtoken.JwtException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class RefreshAuthenticationTest extends IntegrationTestSupport {
-
-    @Autowired
-    private AuthenticationService authenticationService;
-
-    @Autowired
-    private SignUpService signUpService;
-
-    @Autowired
-    private JwtAuthenticationManager jwtAuthenticationManager;
-
-    @Autowired
-    private JwtTokenGenerator tokenGenerator;
+public class RefreshAuthenticationTest extends UserTestSupport {
 
     @DisplayName("액세스 토큰과 리프레시 토큰을 통해 토큰을 재발급받는다.")
     @Test

--- a/src/test/java/com/directors/application/user/SignUpServiceTest.java
+++ b/src/test/java/com/directors/application/user/SignUpServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class SignUpServiceTest extends UserTestSupport {
 
@@ -55,6 +56,23 @@ class SignUpServiceTest extends UserTestSupport {
         assertThatThrownBy(() -> signUpService.isDuplicatedUser(givenId))
                 .isInstanceOf(DuplicateIdException.class)
                 .hasMessage("이미 존재하는 Id입니다.");
+    }
+
+    @DisplayName("기존에 아이디가 없는 경우 예외가 발생하지 않는다.")
+    @Test
+    void isDuplicatedUserWithNotRegisteredUserId() {
+        // given
+        String givenId = "cnsong1234";
+        String notRegisteredUserId = "songsong";
+
+        SignUpRequest request = createSignUpRequest(givenId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(request);
+
+        // when
+        signUpService.isDuplicatedUser(notRegisteredUserId);
+
+        // then
+        assertFalse(Thread.currentThread().isInterrupted());
     }
 
     private static SignUpRequest createSignUpRequest(String userId, String password, String name, String nickname, String email, String phoneNumber) {

--- a/src/test/java/com/directors/application/user/SignUpServiceTest.java
+++ b/src/test/java/com/directors/application/user/SignUpServiceTest.java
@@ -1,20 +1,15 @@
 package com.directors.application.user;
 
-import com.directors.IntegrationTestSupport;
 import com.directors.domain.user.exception.DuplicateIdException;
 import com.directors.presentation.user.request.SignUpRequest;
 import com.directors.presentation.user.response.SignUpResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class SignUpServiceTest extends IntegrationTestSupport {
-
-    @Autowired
-    private SignUpService signUpService;
+class SignUpServiceTest extends UserTestSupport {
 
     @DisplayName("회원 정보를 통해 회원 가입을 한다.")
     @Test

--- a/src/test/java/com/directors/application/user/SignUpServiceTest.java
+++ b/src/test/java/com/directors/application/user/SignUpServiceTest.java
@@ -1,0 +1,75 @@
+package com.directors.application.user;
+
+import com.directors.IntegrationTestSupport;
+import com.directors.domain.user.exception.DuplicateIdException;
+import com.directors.presentation.user.request.SignUpRequest;
+import com.directors.presentation.user.response.SignUpResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SignUpServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private SignUpService signUpService;
+
+    @DisplayName("회원 정보를 통해 회원 가입을 한다.")
+    @Test
+    void signUp() {
+        // given
+        SignUpRequest request = createSignUpRequest("cnsong1234", "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+
+        // when
+        SignUpResponse signUpResponse = signUpService.signUp(request);
+
+        // then
+        assertThat(signUpResponse.id()).isNotNull();
+        assertThat(signUpResponse)
+                .extracting("id", "name", "nickname", "email", "phoneNumber")
+                .contains("cnsong1234", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+    }
+
+    @DisplayName("기존에 가입된 아이디 있을 경우 회원 가입을 할 수 없다.")
+    @Test
+    void signUpWithDuplicateId() {
+        // given
+        SignUpRequest request = createSignUpRequest("cnsong1234", "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(request);
+
+        SignUpRequest duplicateRequest = createSignUpRequest("cnsong1234", "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+
+        // when then
+        assertThatThrownBy(() -> signUpService.signUp(duplicateRequest))
+                .isInstanceOf(DuplicateIdException.class)
+                .hasMessage("이미 존재하는 Id입니다.");
+    }
+
+    @DisplayName("기존에 아이디가 있는 경우 예외가 발생한다.")
+    @Test
+    void isDuplicatedUser() {
+        // given
+        String givenId = "cnsong1234";
+
+        SignUpRequest request = createSignUpRequest(givenId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(request);
+
+        // when then
+        assertThatThrownBy(() -> signUpService.isDuplicatedUser(givenId))
+                .isInstanceOf(DuplicateIdException.class)
+                .hasMessage("이미 존재하는 Id입니다.");
+    }
+
+    private static SignUpRequest createSignUpRequest(String userId, String password, String name, String nickname, String email, String phoneNumber) {
+        return SignUpRequest.builder()
+                .userId(userId)
+                .password(password)
+                .name(name)
+                .nickname(nickname)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+}

--- a/src/test/java/com/directors/application/user/UpdateUserServiceTest.java
+++ b/src/test/java/com/directors/application/user/UpdateUserServiceTest.java
@@ -1,0 +1,150 @@
+package com.directors.application.user;
+
+import com.directors.domain.user.User;
+import com.directors.domain.user.UserStatus;
+import com.directors.domain.user.exception.AuthenticationFailedException;
+import com.directors.presentation.user.request.*;
+import com.directors.presentation.user.response.LogInResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class UpdateUserServiceTest extends UserTestSupport {
+
+    @DisplayName("패스워드를 수정한다.")
+    @Test
+    void updatePassword() {
+        // given
+        String givenUserId = "cnsong1234";
+        String oldPassword = "1234567890";
+        String newPassword = "987654321";
+
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, oldPassword, "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        UpdatePasswordRequest request = createUpdatePasswordRequest(oldPassword, newPassword);
+
+        // when
+        updateUserService.updatePassword(request, givenUserId);
+
+        // then
+        assertFalse(Thread.currentThread().isInterrupted());
+
+        LogInRequest loginRequest = UserTestHelper.createLogInRequest(givenUserId, newPassword);
+        LogInResponse logInResponse = authenticationService.logIn(loginRequest);
+
+        assertThat(logInResponse).isNotNull();
+        assertThat(logInResponse.accessToken()).isNotBlank();
+        assertThat(logInResponse.refreshToken()).isNotBlank();
+    }
+
+    @DisplayName("잘못된 기존 패스워드로 수정 요청 시 예외가 발생한다.")
+    @Test
+    void updatePasswordWithWrongDefaultPassword() {
+        // given
+        String givenUserId = "cnsong1234";
+        String oldPassword = "1234567890";
+        String newPassword = "987654321";
+
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, oldPassword, "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        UpdatePasswordRequest request = createUpdatePasswordRequest(newPassword, newPassword);
+
+        // when then
+        assertThatThrownBy(() -> updateUserService.updatePassword(request, givenUserId))
+                .isInstanceOf(AuthenticationFailedException.class)
+                .hasMessage("유저 인증이 실패했습니다.");
+    }
+
+    @DisplayName("탈퇴한 회원의 토큰을 이용해 패스워드 수정 요청 시 예외가 발생한다.")
+    @Test
+    void updatePasswordWithUnregisteredUserId() {
+        // given
+        String givenUserId = "cnsong1234";
+        String oldPassword = "1234567890";
+        String newPassword = "987654321";
+
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, oldPassword, "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        WithdrawRequest withdrawRequest = createWithdrawRequest(givenUserId, oldPassword);
+        withdrawService.withdraw(withdrawRequest, givenUserId);
+
+        UpdatePasswordRequest request = createUpdatePasswordRequest(oldPassword, newPassword);
+
+        // when then
+        assertThatThrownBy(() -> updateUserService.updatePassword(request, givenUserId))
+                .isInstanceOf(AuthenticationFailedException.class)
+                .hasMessage("유저 인증이 실패했습니다.");
+    }
+
+    @DisplayName("이메일을 수정한다.")
+    @Test
+    void updateEmail() {
+        // given
+        String givenUserId = "cnsong1234";
+        String oldEmail = "cnsong0229@gmail.com";
+        String newEmail = "songsong@gmail.com";
+
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567879", "송은석", "cnsong0229", oldEmail, "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        UpdateEmailRequest updateEmailRequest = new UpdateEmailRequest(newEmail);
+
+        // when
+        updateUserService.updateEmail(updateEmailRequest, givenUserId);
+
+        // then
+        assertFalse(Thread.currentThread().isInterrupted());
+
+        User user = userRepository.findByIdAndUserStatus(givenUserId, UserStatus.JOINED)
+                .orElseThrow(null);
+
+        assertThat(user.getEmail()).isEqualTo(newEmail);
+    }
+
+    @DisplayName("탈퇴한 회원의 토큰을 이용해 이메일 수정 요청 시 예외가 발생한다.")
+    @Test
+    void updateEmailWithUnregisteredUserId() {
+        // given
+        String givenUserId = "cnsong1234";
+        String oldEmail = "cnsong0229@gmail.com";
+        String newEmail = "songsong@gmail.com";
+
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567879", "송은석", "cnsong0229", oldEmail, "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        WithdrawRequest withdrawRequest = createWithdrawRequest(givenUserId, "1234567879");
+        withdrawService.withdraw(withdrawRequest, givenUserId);
+
+        UpdateEmailRequest updateEmailRequest = new UpdateEmailRequest(newEmail);
+
+        // when then
+        assertThatThrownBy(() -> updateUserService.updateEmail(updateEmailRequest, givenUserId))
+                .isInstanceOf(AuthenticationFailedException.class)
+                .hasMessage("유저 인증이 실패했습니다.");
+    }
+
+    private static UpdatePasswordRequest createUpdatePasswordRequest(String oldPassword, String newPassword) {
+        return UpdatePasswordRequest.builder()
+                .oldPassword(oldPassword)
+                .newPassword(newPassword)
+                .build();
+    }
+
+    private static WithdrawRequest createWithdrawRequest(String userId, String password) {
+        return WithdrawRequest.builder()
+                .userId(userId)
+                .password(password)
+                .build();
+    }
+}

--- a/src/test/java/com/directors/application/user/UpdateUserServiceTest.java
+++ b/src/test/java/com/directors/application/user/UpdateUserServiceTest.java
@@ -64,7 +64,7 @@ class UpdateUserServiceTest extends UserTestSupport {
 
     @DisplayName("탈퇴한 회원의 토큰을 이용해 패스워드 수정 요청 시 예외가 발생한다.")
     @Test
-    void updatePasswordWithUnregisteredUserId() {
+    void updatePasswordWithNotRegisteredUserId() {
         // given
         String givenUserId = "cnsong1234";
         String oldPassword = "1234567890";
@@ -113,7 +113,7 @@ class UpdateUserServiceTest extends UserTestSupport {
 
     @DisplayName("탈퇴한 회원의 토큰을 이용해 이메일 수정 요청 시 예외가 발생한다.")
     @Test
-    void updateEmailWithUnregisteredUserId() {
+    void updateEmailWithNotRegisteredUserId() {
         // given
         String givenUserId = "cnsong1234";
         String oldEmail = "cnsong0229@gmail.com";

--- a/src/test/java/com/directors/application/user/UserTestHelper.java
+++ b/src/test/java/com/directors/application/user/UserTestHelper.java
@@ -1,0 +1,24 @@
+package com.directors.application.user;
+
+import com.directors.presentation.user.request.LogInRequest;
+import com.directors.presentation.user.request.SignUpRequest;
+
+public class UserTestHelper {
+    public static LogInRequest createLogInRequest(String userId, String password) {
+        return LogInRequest.builder()
+                .userId(userId)
+                .password(password)
+                .build();
+    }
+
+    public static SignUpRequest createSignUpRequest(String userId, String password, String name, String nickname, String email, String phoneNumber) {
+        return SignUpRequest.builder()
+                .userId(userId)
+                .password(password)
+                .name(name)
+                .nickname(nickname)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+}

--- a/src/test/java/com/directors/application/user/UserTestSupport.java
+++ b/src/test/java/com/directors/application/user/UserTestSupport.java
@@ -1,0 +1,34 @@
+package com.directors.application.user;
+
+import com.directors.IntegrationTestSupport;
+import com.directors.domain.auth.TokenRepository;
+import com.directors.domain.user.UserRepository;
+import com.directors.infrastructure.auth.JwtAuthenticationManager;
+import com.directors.infrastructure.auth.JwtTokenGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public abstract class UserTestSupport extends IntegrationTestSupport {
+    @Autowired
+    public AuthenticationService authenticationService;
+
+    @Autowired
+    public SignUpService signUpService;
+
+    @Autowired
+    public JwtAuthenticationManager jwtAuthenticationManager;
+
+    @Autowired
+    public UserRepository userRepository;
+
+    @Autowired
+    public TokenRepository tokenRepository;
+
+    @Autowired
+    public JwtTokenGenerator tokenGenerator;
+
+    @Autowired
+    public UpdateUserService updateUserService;
+
+    @Autowired
+    public WithdrawService withdrawService;
+}

--- a/src/test/java/com/directors/application/user/UserTestSupport.java
+++ b/src/test/java/com/directors/application/user/UserTestSupport.java
@@ -31,4 +31,7 @@ public abstract class UserTestSupport extends IntegrationTestSupport {
 
     @Autowired
     public WithdrawService withdrawService;
+
+    @Autowired
+    public AuthenticateRegionService authenticateRegionService;
 }

--- a/src/test/java/com/directors/application/user/WithdrawServiceTest.java
+++ b/src/test/java/com/directors/application/user/WithdrawServiceTest.java
@@ -1,24 +1,16 @@
 package com.directors.application.user;
 
-import com.directors.IntegrationTestSupport;
 import com.directors.domain.user.exception.AuthenticationFailedException;
 import com.directors.presentation.user.request.SignUpRequest;
 import com.directors.presentation.user.request.WithdrawRequest;
 import com.directors.presentation.user.response.WithdrawResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class WithdrawServiceTest extends IntegrationTestSupport {
-
-    @Autowired
-    SignUpService signUpService;
-
-    @Autowired
-    WithdrawService withdrawService;
+class WithdrawServiceTest extends UserTestSupport {
 
     @DisplayName("탈퇴 요청을 통해 회원을 탈퇴 처리한다.")
     @Test
@@ -29,10 +21,8 @@ class WithdrawServiceTest extends IntegrationTestSupport {
                 .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
         signUpService.signUp(signUpRequest);
 
-        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
-                .userId(givenUserId)
-                .password("1234567890")
-                .build();
+
+        WithdrawRequest withdrawRequest = createWithdrawRequest(givenUserId);
 
         // when
         WithdrawResponse response = withdrawService.withdraw(withdrawRequest, givenUserId);
@@ -40,7 +30,6 @@ class WithdrawServiceTest extends IntegrationTestSupport {
         // then
         assertThat(response.userId()).isEqualTo(givenUserId);
     }
-
 
     @DisplayName("회원가입되지 않은 회원 아이디로 탈퇴 요청을 하면 예외가 발생한다.")
     @Test
@@ -51,10 +40,7 @@ class WithdrawServiceTest extends IntegrationTestSupport {
                 .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
         signUpService.signUp(signUpRequest);
 
-        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
-                .userId("wrongUserId")
-                .password("1234567890")
-                .build();
+        WithdrawRequest withdrawRequest = createWithdrawRequest("wrongUserId");
 
         // when then
         assertThatThrownBy(() -> withdrawService.withdraw(withdrawRequest, givenUserId))
@@ -71,10 +57,7 @@ class WithdrawServiceTest extends IntegrationTestSupport {
                 .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
         signUpService.signUp(signUpRequest);
 
-        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
-                .userId(givenUserId)
-                .password("1234567890")
-                .build();
+        WithdrawRequest withdrawRequest = createWithdrawRequest(givenUserId);
         withdrawService.withdraw(withdrawRequest, givenUserId);
 
         // when then
@@ -93,14 +76,18 @@ class WithdrawServiceTest extends IntegrationTestSupport {
                 .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
         signUpService.signUp(signUpRequest);
 
-        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
-                .userId(givenUserId)
-                .password("1234567890")
-                .build();
+        WithdrawRequest withdrawRequest = createWithdrawRequest(givenUserId);
 
         // when then
         assertThatThrownBy(() -> withdrawService.withdraw(withdrawRequest, userIdByToken))
                 .isInstanceOf(AuthenticationFailedException.class)
                 .hasMessage("유저 인증이 실패했습니다.");
+    }
+
+    private static WithdrawRequest createWithdrawRequest(String givenUserId) {
+        return WithdrawRequest.builder()
+                .userId(givenUserId)
+                .password("1234567890")
+                .build();
     }
 }

--- a/src/test/java/com/directors/application/user/WithdrawServiceTest.java
+++ b/src/test/java/com/directors/application/user/WithdrawServiceTest.java
@@ -1,0 +1,106 @@
+package com.directors.application.user;
+
+import com.directors.IntegrationTestSupport;
+import com.directors.domain.user.exception.AuthenticationFailedException;
+import com.directors.presentation.user.request.SignUpRequest;
+import com.directors.presentation.user.request.WithdrawRequest;
+import com.directors.presentation.user.response.WithdrawResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WithdrawServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    SignUpService signUpService;
+
+    @Autowired
+    WithdrawService withdrawService;
+
+    @DisplayName("탈퇴 요청을 통해 회원을 탈퇴 처리한다.")
+    @Test
+    void withdraw() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
+                .userId(givenUserId)
+                .password("1234567890")
+                .build();
+
+        // when
+        WithdrawResponse response = withdrawService.withdraw(withdrawRequest, givenUserId);
+
+        // then
+        assertThat(response.userId()).isEqualTo(givenUserId);
+    }
+
+
+    @DisplayName("회원가입되지 않은 회원 아이디로 탈퇴 요청을 하면 예외가 발생한다.")
+    @Test
+    void withdrawWithUnregisteredUserId() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
+                .userId("wrongUserId")
+                .password("1234567890")
+                .build();
+
+        // when then
+        assertThatThrownBy(() -> withdrawService.withdraw(withdrawRequest, givenUserId))
+                .isInstanceOf(AuthenticationFailedException.class)
+                .hasMessage("유저 인증이 실패했습니다.");
+    }
+
+    @DisplayName("이미 탈퇴한 회원 아이디로 탈퇴 요청을 하면 예외가 발생한다.")
+    @Test
+    void withdrawWithWithdrawalUserId() {
+        // given
+        String givenUserId = "cnsong1234";
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
+                .userId(givenUserId)
+                .password("1234567890")
+                .build();
+        withdrawService.withdraw(withdrawRequest, givenUserId);
+
+        // when then
+        assertThatThrownBy(() -> withdrawService.withdraw(withdrawRequest, givenUserId))
+                .isInstanceOf(AuthenticationFailedException.class)
+                .hasMessage("유저 인증이 실패했습니다.");
+    }
+
+    @DisplayName("탈퇴 요청한 회원 아이디와 토큰의 회원 아이디가 다르면 예외가 발생한다.")
+    @Test
+    void withdrawWithWrongToken() {
+        // given
+        String givenUserId = "cnsong1234";
+        String userIdByToken = "userIdByToken";
+        SignUpRequest signUpRequest = UserTestHelper
+                .createSignUpRequest(givenUserId, "1234567890", "송은석", "cnsong0229", "thddmstjrwkd@naver.com", "01077021045");
+        signUpService.signUp(signUpRequest);
+
+        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
+                .userId(givenUserId)
+                .password("1234567890")
+                .build();
+
+        // when then
+        assertThatThrownBy(() -> withdrawService.withdraw(withdrawRequest, userIdByToken))
+                .isInstanceOf(AuthenticationFailedException.class)
+                .hasMessage("유저 인증이 실패했습니다.");
+    }
+}

--- a/src/test/java/com/directors/application/user/WithdrawServiceTest.java
+++ b/src/test/java/com/directors/application/user/WithdrawServiceTest.java
@@ -33,7 +33,7 @@ class WithdrawServiceTest extends UserTestSupport {
 
     @DisplayName("회원가입되지 않은 회원 아이디로 탈퇴 요청을 하면 예외가 발생한다.")
     @Test
-    void withdrawWithUnregisteredUserId() {
+    void withdrawWithNotRegisteredUserId() {
         // given
         String givenUserId = "cnsong1234";
         SignUpRequest signUpRequest = UserTestHelper

--- a/src/test/java/com/directors/domain/user/UserRepositoryTest.java
+++ b/src/test/java/com/directors/domain/user/UserRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.directors.domain.user;
+
+import com.directors.IntegrationTestSupport;
+import com.directors.domain.user.exception.NoSuchUserException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("회원 가입 상태인 유저 아이디로 유저를 조회한다.")
+    @Test
+    void findJoindedUserById() {
+        // given
+        String testId = "cnsong";
+        User user = createUser(testId, "1234567890", "thddmstjrwkd@naver.com", "01077021045", "송은석", "cnsong");
+        userRepository.save(user);
+
+        // when
+        User findUser = userRepository.findByIdAndUserStatus(testId, UserStatus.JOINED)
+                .orElseThrow(null);
+
+        // then
+        assertThat(findUser.getId()).isNotNull().isEqualTo(testId);
+        assertThat(findUser).extracting("password", "email", "phoneNumber", "name", "nickname")
+                .contains(user.getPassword(), user.getEmail(), user.getPhoneNumber(), user.getName(), user.getNickname());
+    }
+
+    @DisplayName("가입되지 않은 유저 아이디로 유저를 조회하면 예외가 발생한다.")
+    @Test
+    void findUnregisteredIdById() {
+        // given
+        String testId = "cnsong";
+        User user = createUser(testId, "1234567890", "thddmstjrwkd@naver.com", "01077021045", "송은석", "cnsong");
+        userRepository.save(user);
+
+        String unregisteredId = "tnsong";
+
+        // when // then
+        assertThatThrownBy(() -> userRepository.findByIdAndUserStatus(unregisteredId, UserStatus.JOINED)
+                .orElseThrow(() -> new NoSuchUserException(unregisteredId)))
+                .isInstanceOf(NoSuchUserException.class)
+                .hasMessage("존재하지 않는 유저 Id입니다.");
+    }
+
+    @DisplayName("탈퇴한 유저 아이디를 가입한 유저로 조회하면 예외가 발생한다.")
+    @Test
+    void findWithdrawnIdById() {
+        // given
+        String testId = "cnsong";
+        User user = createUser(testId, "1234567890", "thddmstjrwkd@naver.com", "01077021045", "송은석", "cnsong");
+        User saveUser = userRepository.save(user);
+
+        LocalDateTime now = LocalDateTime.now();
+        saveUser.withdrawal(now);
+
+        // when // then
+        assertThatThrownBy(() -> userRepository.findByIdAndUserStatus(testId, UserStatus.JOINED)
+                .orElseThrow(() -> new NoSuchUserException(testId)))
+                .isInstanceOf(NoSuchUserException.class)
+                .hasMessage("존재하지 않는 유저 Id입니다.");
+    }
+
+    // TODO: 05.05 findWithSearchConditions 는 추후 테스트
+
+    private User createUser(String id, String password, String email, String phoneNumber, String name, String nickname) {
+        return User.builder()
+                .id(id)
+                .password(password)
+                .userStatus(UserStatus.JOINED)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .name(name)
+                .reward(0L)
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/src/test/java/com/directors/infrastructure/api/RegionApiClientManagerTest.java
+++ b/src/test/java/com/directors/infrastructure/api/RegionApiClientManagerTest.java
@@ -1,0 +1,44 @@
+package com.directors.infrastructure.api;
+
+import com.directors.IntegrationTestSupport;
+import com.directors.domain.region.Address;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RegionApiClientManagerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RegionApiClientManager regionApiClientManager;
+
+    @DisplayName("UTM-K 기반 위치 정보를 통해 주소를 조회한다.")
+    @Test
+    void findRegionAddressByLocation() {
+        // given
+        long latitude = 961487;
+        long longitude = 1949977;
+
+        // when
+        Address address = regionApiClientManager.findRegionAddressByLocation(latitude, longitude);
+
+        // then
+        assertThat(address)
+                .extracting("fullAddress", "unitAddress")
+                .contains("서울특별시 성동구 송정동", "송정동");
+    }
+
+    @DisplayName("잘못된 위치 정보를 통해 주소를 조회할 경우 예외가 발생한다.")
+    @Test
+    void findRegionAddressByWrongLocation() {
+        // given
+        long latitude = 10;
+        long longitude = 10;
+
+        // when then
+        assertThatThrownBy(() -> regionApiClientManager.findRegionAddressByLocation(latitude, longitude))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/directors/infrastructure/api/RegionApiTokenProviderFailTest.java
+++ b/src/test/java/com/directors/infrastructure/api/RegionApiTokenProviderFailTest.java
@@ -1,0 +1,32 @@
+package com.directors.infrastructure.api;
+
+import com.directors.infrastructure.exception.api.RenewApiKeyException;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Disabled
+@ActiveProfiles("test")
+@SpringBootTest
+@TestPropertySource(properties = {
+        "CONSUMER_KEY=WRONG_KEY",
+        "CONSUMER_SECRET=WRONG_SECRET",
+})
+public class RegionApiTokenProviderFailTest {
+
+    @Autowired
+    private RegionApiTokenProvider regionApiTokenProvider;
+
+    @DisplayName("잘못된 api 키를 통해 인증 토큰을 발급 받으려 할 경우 예외가 발생한다.")
+    @Test
+    void fetchApiAccessTokenFromAPIWithWrongKey() {
+        assertThatThrownBy(() -> regionApiTokenProvider.fetchApiAccessTokenFromAPI())
+                .isInstanceOf(RenewApiKeyException.class);
+    }
+}

--- a/src/test/java/com/directors/infrastructure/api/RegionApiTokenProviderSuccessTest.java
+++ b/src/test/java/com/directors/infrastructure/api/RegionApiTokenProviderSuccessTest.java
@@ -1,0 +1,25 @@
+package com.directors.infrastructure.api;
+
+import com.directors.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class RegionApiTokenProviderSuccessTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RegionApiTokenProvider regionApiTokenProvider;
+
+    @DisplayName("api 키를 통해 sgis로부터 인증 토큰을 발급 받는다.")
+    @Test
+    void fetchApiAccessTokenFromAPI() {
+        // given when
+        String token = regionApiTokenProvider.fetchApiAccessTokenFromAPI();
+
+        // then
+        assertThat(token).isNotNull();
+    }
+}

--- a/src/test/java/com/directors/learningTest/geoApiTest/GetAdministrativeDistrictTest.java
+++ b/src/test/java/com/directors/learningTest/geoApiTest/GetAdministrativeDistrictTest.java
@@ -65,9 +65,6 @@ public class GetAdministrativeDistrictTest {
     @Test
     public void 지오코딩_API요청_성공테스트() {
         // GIVEN
-        long x = 961487;  // UTM-K 기반 x, y 좌표
-        long y = 1949977;
-
         UriComponents uri = UriComponentsBuilder  // 요청 uri 정의
                 .fromHttpUrl(지오코딩RequestUrl)
                 .queryParam("address", "서울시 중구 회현동")
@@ -88,13 +85,11 @@ public class GetAdministrativeDistrictTest {
         assertThat(map.get("y")).isEqualTo("1951021.30829999992");
     }
 
-    @Disabled
     @Test
     public void 좌표에_대한_행정동_획득_동기반_지역명_API요청_성공테스트() {
         // GIVEN
         long x = 961487;  // UTM-K 기반 x, y 좌표
         long y = 1949977;
-
         UriComponents uri = UriComponentsBuilder  // 요청 uri 정의
                 .fromHttpUrl(리버스지오코딩RequestUrl)
                 .queryParam("x_coor", x)


### PR DESCRIPTION
## PR 유형

- [x] 버그 수정
- [ ] 기능
- [ ] 코드 스타일
- [x] 리팩토링
- [ ] 빌드
- [ ] CI/CD
- [ ] 문서
- [x] 기타
  <br>

## 변경사항

### 변경 전
- 유저 도메인의 서비스와 레포지토리 관련 테스트 x
### 변경 후
- 아래의 유저 도메인의 서비스 클래스를 위한 테스트 코드를 작성했습니다.
  - SigupService
  - AuthenticationService
  - WithdrawService
  - UpdateUserService 

- 테스트한 서비스에서 사용하고 있는 아래의 클래스를 테스트했습니다.
  - RegionApiClientManager 
  - RegionApiTokenProvider 

- 유저 레포지토리 관련 테스트를 작성했습니다.

- 테스트와 함께 코드를 개선하고, 리팩토링했습니다. 구체적인 내용은 아래와 같습니다.
  - 테스트에 필요한 dto 작성
  - 기존 클래스에서 책임을 분리한 새로운 컴포넌트 추가 
    - RegionApiClientManager 로부터 외부 api의 응답을 validate의 책임을 분리한 ApiResponseValidator
    - JwtAuthenticationManager 로부터 토큰 생성의 책임을 분리한 JwtTokenGenerator
  - 코드 개선 과정에서 필요 없는 예외를 제거하고, 필요한 예외를 추가. 
    - 제거된 예외 - NotFoundException, ExternalApiServerException, exteralApiAuthenticationException
    - 추가한 예외 RenewApiKeyException

## 기타
- 유저 서비스 중 SearchDirectorService는 테스트 되지 않았습니다. 추후 테스트를 추가할 예정입니다.